### PR TITLE
feat(EXPAND-010): OSM インポーター拡張（新規レコード生成）

### DIFF
--- a/batch/osm_geocoder.py
+++ b/batch/osm_geocoder.py
@@ -37,6 +37,7 @@ from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from db import get_engine
+from parsers import PARSERS
 
 logger = logging.getLogger(__name__)
 
@@ -56,8 +57,27 @@ PREFECTURE_NAMES = [
 ]
 
 # 公式パーサーが実装済みの都道府県（--import-new --all 時に除外）
-PARSER_IMPLEMENTED_PREFECTURES = {
-    "東京都", "京都府", "福岡県", "大阪府", "愛知県",
+# parsers/__init__.py の PARSERS dict から自動参照することで手動更新不要
+PARSER_IMPLEMENTED_PREFECTURES: set[str] = set(PARSERS.keys())
+
+# 都道府県 → 地域区分マッピング（INSERT 時の region カラムに使用）
+PREFECTURE_TO_REGION: dict[str, str] = {
+    "北海道": "北海道",
+    "青森県": "東北", "岩手県": "東北", "宮城県": "東北",
+    "秋田県": "東北", "山形県": "東北", "福島県": "東北",
+    "茨城県": "関東", "栃木県": "関東", "群馬県": "関東",
+    "埼玉県": "関東", "千葉県": "関東", "東京都": "関東", "神奈川県": "関東",
+    "新潟県": "中部", "富山県": "中部", "石川県": "中部", "福井県": "中部",
+    "山梨県": "中部", "長野県": "中部", "岐阜県": "中部",
+    "静岡県": "中部", "愛知県": "中部",
+    "三重県": "近畿", "滋賀県": "近畿", "京都府": "近畿",
+    "大阪府": "近畿", "兵庫県": "近畿", "奈良県": "近畿", "和歌山県": "近畿",
+    "鳥取県": "中国", "島根県": "中国", "岡山県": "中国",
+    "広島県": "中国", "山口県": "中国",
+    "徳島県": "四国", "香川県": "四国", "愛媛県": "四国", "高知県": "四国",
+    "福岡県": "九州", "佐賀県": "九州", "長崎県": "九州",
+    "熊本県": "九州", "大分県": "九州", "宮崎県": "九州",
+    "鹿児島県": "九州", "沖縄県": "九州",
 }
 
 
@@ -320,11 +340,11 @@ def import_new_prefecture(
                     """
                     INSERT INTO sentos
                         (name, address, lat, lng, phone, url, open_hours, holiday,
-                         prefecture, source_url, geocoded_by, facility_type,
+                         prefecture, region, source_url, geocoded_by, facility_type,
                          created_at, updated_at)
                     VALUES
                         (:name, :address, :lat, :lng, :phone, :url, :open_hours, :holiday,
-                         :prefecture, :source_url, 'osm', :facility_type,
+                         :prefecture, :region, :source_url, 'osm', :facility_type,
                          NOW(), NOW())
                     """
                 ),
@@ -338,6 +358,7 @@ def import_new_prefecture(
                     "open_hours": tags.get("opening_hours"),
                     "holiday": None,
                     "prefecture": prefecture,
+                    "region": PREFECTURE_TO_REGION.get(prefecture),
                     "source_url": source_url,
                     "facility_type": facility_type,
                 },
@@ -406,23 +427,24 @@ def main() -> None:
     total_skipped = 0
     total_total = 0
 
-    for i, pref in enumerate(prefectures):
-        if args.import_new:
-            primary, skipped, total = import_new_prefecture(session, pref, dry_run=args.dry_run)
-            logger.info("%s: INSERT=%d / スキップ=%d / 合計=%d", pref, primary, skipped, total)
-        else:
-            primary, skipped, total = geocode_prefecture(session, pref, dry_run=args.dry_run)
-            logger.info("%s: 座標補完=%d / スキップ=%d / 対象=%d", pref, primary, skipped, total)
+    try:
+        for i, pref in enumerate(prefectures):
+            if args.import_new:
+                primary, skipped, total = import_new_prefecture(session, pref, dry_run=args.dry_run)
+                logger.info("%s: INSERT=%d / スキップ=%d / 合計=%d", pref, primary, skipped, total)
+            else:
+                primary, skipped, total = geocode_prefecture(session, pref, dry_run=args.dry_run)
+                logger.info("%s: 座標補完=%d / スキップ=%d / 対象=%d", pref, primary, skipped, total)
 
-        total_primary += primary
-        total_skipped += skipped
-        total_total += total
+            total_primary += primary
+            total_skipped += skipped
+            total_total += total
 
-        # 都道府県間のインターバル（Overpass API への負荷軽減）
-        if args.all and i < len(prefectures) - 1 and total > 0:
-            time.sleep(5)
-
-    session.close()
+            # 都道府県間のインターバル（Overpass API への負荷軽減）
+            if args.all and i < len(prefectures) - 1 and total > 0:
+                time.sleep(5)
+    finally:
+        session.close()
 
     if args.import_new:
         logger.info(

--- a/batch/tests/test_osm_geocoder.py
+++ b/batch/tests/test_osm_geocoder.py
@@ -1,0 +1,153 @@
+"""osm_geocoder モジュールのユニットテスト。"""
+import pytest
+
+from osm_geocoder import (
+    _build_address,
+    extract_coords,
+    find_best_match,
+    resolve_facility_type,
+)
+
+
+# ---------------------------------------------------------------------------
+# resolve_facility_type
+# ---------------------------------------------------------------------------
+
+def test_resolve_facility_type_spa() -> None:
+    assert resolve_facility_type({"amenity": "spa"}) == "super_sento"
+
+
+def test_resolve_facility_type_onsen() -> None:
+    assert resolve_facility_type({"amenity": "public_bath", "bath:type": "onsen"}) == "onsen"
+
+
+def test_resolve_facility_type_sento() -> None:
+    assert resolve_facility_type({"amenity": "public_bath"}) == "sento"
+
+
+def test_resolve_facility_type_sento_unknown_bath_type() -> None:
+    assert resolve_facility_type({"amenity": "public_bath", "bath:type": "other"}) == "sento"
+
+
+def test_resolve_facility_type_empty_tags() -> None:
+    assert resolve_facility_type({}) == "sento"
+
+
+# ---------------------------------------------------------------------------
+# extract_coords
+# ---------------------------------------------------------------------------
+
+def test_extract_coords_node() -> None:
+    element = {"type": "node", "lat": 35.6895, "lon": 139.6917}
+    lat, lng = extract_coords(element)
+    assert lat == pytest.approx(35.6895)
+    assert lng == pytest.approx(139.6917)
+
+
+def test_extract_coords_way_with_center() -> None:
+    element = {"type": "way", "center": {"lat": 35.1234, "lon": 136.9876}}
+    lat, lng = extract_coords(element)
+    assert lat == pytest.approx(35.1234)
+    assert lng == pytest.approx(136.9876)
+
+
+def test_extract_coords_way_without_center() -> None:
+    element = {"type": "way"}
+    lat, lng = extract_coords(element)
+    assert lat is None
+    assert lng is None
+
+
+def test_extract_coords_relation_with_center() -> None:
+    element = {"type": "relation", "center": {"lat": 43.0621, "lon": 141.3544}}
+    lat, lng = extract_coords(element)
+    assert lat == pytest.approx(43.0621)
+    assert lng == pytest.approx(141.3544)
+
+
+# ---------------------------------------------------------------------------
+# find_best_match
+# ---------------------------------------------------------------------------
+
+def _make_element(name: str, lat: float = 35.0, lon: float = 135.0) -> dict:
+    return {
+        "type": "node",
+        "lat": lat,
+        "lon": lon,
+        "tags": {"name": name, "amenity": "public_bath"},
+    }
+
+
+def test_find_best_match_exact() -> None:
+    elements = [_make_element("鶴の湯"), _make_element("亀の湯")]
+    result = find_best_match("鶴の湯", "東京都港区1-1-1", elements)
+    assert result is not None
+    assert result["tags"]["name"] == "鶴の湯"
+
+
+def test_find_best_match_above_threshold() -> None:
+    elements = [_make_element("松の湯銭湯")]
+    result = find_best_match("松の湯", "大阪市中央区1-1", elements)
+    assert result is not None
+    assert result["tags"]["name"] == "松の湯銭湯"
+
+
+def test_find_best_match_below_threshold_returns_none() -> None:
+    elements = [_make_element("全然違う名前の施設")]
+    result = find_best_match("鶴の湯", "東京都港区1-1-1", elements)
+    assert result is None
+
+
+def test_find_best_match_empty_list() -> None:
+    result = find_best_match("鶴の湯", "東京都港区1-1-1", [])
+    assert result is None
+
+
+def test_find_best_match_element_without_name_is_skipped() -> None:
+    elements = [{"type": "node", "lat": 35.0, "lon": 135.0, "tags": {}}]
+    result = find_best_match("鶴の湯", "東京都港区1-1-1", elements)
+    assert result is None
+
+
+def test_find_best_match_returns_highest_score() -> None:
+    elements = [
+        _make_element("竹の湯"),
+        _make_element("竹の湯銭湯"),  # より類似度が高い
+    ]
+    result = find_best_match("竹の湯銭湯", "埼玉県浦和市1-1", elements)
+    assert result is not None
+    assert result["tags"]["name"] == "竹の湯銭湯"
+
+
+# ---------------------------------------------------------------------------
+# _build_address
+# ---------------------------------------------------------------------------
+
+def test_build_address_with_addr_tags() -> None:
+    tags = {
+        "addr:city": "札幌市",
+        "addr:suburb": "中央区",
+        "addr:street": "大通西",
+        "addr:housenumber": "1",
+    }
+    result = _build_address(tags, "北海道")
+    assert result == "札幌市中央区大通西1"
+
+
+def test_build_address_fallback_to_prefecture() -> None:
+    result = _build_address({}, "大分県")
+    assert result == "大分県"
+
+
+def test_build_address_partial_tags() -> None:
+    tags = {"addr:city": "福岡市"}
+    result = _build_address(tags, "福岡県")
+    assert result == "福岡市"
+
+
+def test_build_address_addr_full_takes_precedence_in_caller() -> None:
+    # _build_address 自体は addr:full を扱わない（呼び出し元で処理）
+    # addr:full がない場合にフォールバックで呼ばれる前提
+    tags = {"addr:province": "愛知県", "addr:city": "名古屋市"}
+    result = _build_address(tags, "愛知県")
+    assert result == "愛知県名古屋市"

--- a/issue-todo/EXPAND-010-osm-importer.md
+++ b/issue-todo/EXPAND-010-osm-importer.md
@@ -33,6 +33,6 @@ uv run python osm_geocoder.py --import-new --all
 `feature/expand-010-osm-importer`
 
 ## ステータス
-- [ ] 実装
-- [ ] テスト
-- [ ] PR
+- [x] 実装
+- [x] テスト
+- [x] PR


### PR DESCRIPTION
## Summary
- `--import-new` フラグを追加。OSM の `amenity=public_bath` + `amenity=spa` から新規レコードを INSERT できるようにした
- `source_url = "osm:{element_id}"` で重複チェック・SKIP
- `facility_type` 自動判定（EXPAND-006 依存）

## facility_type マッピング
| OSM タグ | facility_type |
|---|---|
| `amenity=spa` | `super_sento` |
| `amenity=public_bath` + `bath:type=onsen` | `onsen` |
| `amenity=public_bath`（その他） | `sento` |

## 利用例
```bash
# 大分県の銭湯を OSM からインポート（ドライラン）
uv run python osm_geocoder.py --import-new --prefecture 大分県 --dry-run

# 全都道府県（公式パーサー実装済みの東京・京都・福岡を除外）
uv run python osm_geocoder.py --import-new --all
```

## Test plan
- [x] `--import-new` と既存の座標補完モードが排他になっていることを確認
- [x] `resolve_facility_type` のロジックレビュー
- [x] `_build_address` フォールバック動作確認

**Note**: EXPAND-006（facility_type カラム追加 PR #1）のマージ後に有効になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)