### PR TITLE
feat: 青森県OSMインポートのdry-run検証をDB非依存化

### DIFF
--- a/batch/osm_geocoder.py
+++ b/batch/osm_geocoder.py
@@ -266,17 +266,21 @@ def geocode_prefecture(
 
 
 def import_new_prefecture(
-    session: Session,
+    session: Optional[Session],
     prefecture: str,
     dry_run: bool = False,
 ) -> tuple[int, int, int]:
     """指定都道府県の OSM 施設データを新規 INSERT する。
 
     source_url = "osm:{element_id}" で重複チェックし、未登録のみ INSERT する。
+    dry-run かつ session=None の場合は重複チェックを行わない。
 
     Returns:
         (inserted, skipped, total) のタプル
     """
+    if not dry_run and session is None:
+        raise ValueError("non-dry-run では DB セッションが必要です")
+
     elements = fetch_osm_bath_facilities(prefecture)
     if not elements:
         logger.warning("%s: OSM データ取得失敗", prefecture)
@@ -308,16 +312,16 @@ def import_new_prefecture(
             skipped += 1
             continue
 
-        # 重複チェック
-        existing = session.execute(
-            text("SELECT id FROM sentos WHERE source_url = :source_url"),
-            {"source_url": source_url},
-        ).fetchone()
-
-        if existing:
-            logger.debug("既存レコード SKIP: %s (source_url=%s)", name, source_url)
-            skipped += 1
-            continue
+        if session is not None:
+            # 重複チェック（dry-run + session=None の場合はスキップ）
+            existing = session.execute(
+                text("SELECT id FROM sentos WHERE source_url = :source_url"),
+                {"source_url": source_url},
+            ).fetchone()
+            if existing:
+                logger.debug("既存レコード SKIP: %s (source_url=%s)", name, source_url)
+                skipped += 1
+                continue
 
         address = (
             tags.get("addr:full")
@@ -406,11 +410,15 @@ def main() -> None:
         stream=sys.stderr,
     )
 
-    engine = get_engine()
-    session = Session(engine)
+    session: Optional[Session] = None
+    if not (args.import_new and args.dry_run):
+        engine = get_engine()
+        session = Session(engine)
 
     if args.dry_run:
         logger.info("ドライランモード: DB 更新はスキップします")
+        if args.import_new:
+            logger.info("import-new dry-run: DB 接続なしで OSM データ検証を実行します")
 
     if args.all:
         if args.import_new:
@@ -444,7 +452,8 @@ def main() -> None:
             if args.all and i < len(prefectures) - 1 and total > 0:
                 time.sleep(5)
     finally:
-        session.close()
+        if session is not None:
+            session.close()
 
     if args.import_new:
         logger.info(

--- a/batch/osm_geocoder.py
+++ b/batch/osm_geocoder.py
@@ -410,8 +410,11 @@ def main() -> None:
         stream=sys.stderr,
     )
 
+    # import-new dry-run は OSM データ検証のみで DB 不要。
+    # 一方、geocode_prefecture は dry-run でも DB から対象取得が必要なため DB 接続が必要。
+    needs_db = not (args.import_new and args.dry_run)
     session: Optional[Session] = None
-    if not (args.import_new and args.dry_run):
+    if needs_db:
         engine = get_engine()
         session = Session(engine)
 

--- a/batch/tests/test_osm_geocoder.py
+++ b/batch/tests/test_osm_geocoder.py
@@ -177,6 +177,7 @@ def test_import_new_prefecture_dry_run_without_session(monkeypatch) -> None:
 
     inserted, skipped, total = import_new_prefecture(None, "青森県", dry_run=True)
 
+    # dry-run では DB へ INSERT せず、INSERT 対象件数としてカウントする。
     assert inserted == 1
     assert skipped == 0
     assert total == 1

--- a/batch/tests/test_osm_geocoder.py
+++ b/batch/tests/test_osm_geocoder.py
@@ -5,6 +5,7 @@ from osm_geocoder import (
     _build_address,
     extract_coords,
     find_best_match,
+    import_new_prefecture,
     resolve_facility_type,
 )
 
@@ -151,3 +152,36 @@ def test_build_address_addr_full_takes_precedence_in_caller() -> None:
     tags = {"addr:province": "愛知県", "addr:city": "名古屋市"}
     result = _build_address(tags, "愛知県")
     assert result == "愛知県名古屋市"
+
+
+# ---------------------------------------------------------------------------
+# import_new_prefecture
+# ---------------------------------------------------------------------------
+
+def test_import_new_prefecture_dry_run_without_session(monkeypatch) -> None:
+    elements = [
+        {
+            "type": "node",
+            "id": 123,
+            "lat": 40.8246,
+            "lon": 140.7400,
+            "tags": {
+                "name": "青森湯",
+                "amenity": "public_bath",
+                "bath:type": "onsen",
+                "addr:city": "青森市",
+            },
+        }
+    ]
+    monkeypatch.setattr("osm_geocoder.fetch_osm_bath_facilities", lambda prefecture: elements)
+
+    inserted, skipped, total = import_new_prefecture(None, "青森県", dry_run=True)
+
+    assert inserted == 1
+    assert skipped == 0
+    assert total == 1
+
+
+def test_import_new_prefecture_requires_session_in_non_dry_run() -> None:
+    with pytest.raises(ValueError):
+        import_new_prefecture(None, "青森県", dry_run=False)


### PR DESCRIPTION
## 概要
Issue #11 の対応です。
青森県を OSM から取り込む運用を安全に検証できるよう、`import-new --dry-run` の実行性を改善しました。

## 変更内容
- `batch/osm_geocoder.py`
  - `import_new_prefecture()` の `session` 引数を `Optional[Session]` に変更
  - `dry-run + session=None` を許可し、DB 接続なしで OSM データ検証できるように修正
  - `non-dry-run + session=None` は `ValueError` を送出してガード
  - `main()` で `--import-new --dry-run` 時は DB 接続を作成しないよう変更
- `batch/tests/test_osm_geocoder.py`
  - `dry-run + session=None` で取り込み処理が進むテストを追加
  - `non-dry-run + session=None` が `ValueError` になるテストを追加

## 検証
- `UV_CACHE_DIR=/tmp/.uv-cache uv run pytest`
  - 84 passed
- `UV_CACHE_DIR=/tmp/.uv-cache uv run python osm_geocoder.py --import-new --prefecture 青森県 --dry-run`
  - OSM 取得: 195 件
  - INSERT判定: 189 件 / スキップ: 6 件
  - 取得データで `facility_type` と `lat/lng` がログ出力されることを確認

Closes #11
