### PR TITLE
feat(EXPAND-iwate): 岩手県銭湯パーサー実装

### DIFF
--- a/batch/parsers/__init__.py
+++ b/batch/parsers/__init__.py
@@ -10,6 +10,7 @@ from parsers.hyogo import HyogoParser
 from parsers.saitama import SaitamaParser
 from parsers.chiba import ChibaParser
 from parsers.hokkaido import HokkaidoParser
+from parsers.iwate import IwateParser
 
 PARSERS: dict[str, type[BaseParser]] = {
     "東京都": TokyoParser,
@@ -22,10 +23,11 @@ PARSERS: dict[str, type[BaseParser]] = {
     "埼玉県": SaitamaParser,
     "千葉県": ChibaParser,
     "北海道": HokkaidoParser,
+    "岩手県": IwateParser,
 }
 
 __all__ = [
     "BaseParser", "TokyoParser", "KyotoParser", "FukuokaParser",
     "OsakaParser", "AichiParser", "KanagawaParser", "HyogoParser",
-    "SaitamaParser", "ChibaParser", "HokkaidoParser", "PARSERS",
+    "SaitamaParser", "ChibaParser", "HokkaidoParser", "IwateParser", "PARSERS",
 ]

--- a/batch/parsers/iwate.py
+++ b/batch/parsers/iwate.py
@@ -1,0 +1,212 @@
+"""岩手県公衆浴場業生活衛生同業組合 (seiei.or.jp/iwate) パーサー。
+
+調査メモ:
+- 候補ドメイン `iwate-sento.com` / `iwate1010.jp` は有効な公開サイトを確認できず。
+- 公開検索で確認できた岩手県の公衆浴場組合関連ページを一覧起点にする。
+
+実装方針:
+- 一覧ページから同一ドメイン内の詳細ページ URL を収集
+- 個別ページは dt/dd・table・本文テキストから項目抽出
+- 座標は Google Maps リンク/iframe から抽出。なければ None（OSM 補完対象）
+"""
+import logging
+import re
+from typing import Optional
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+from parsers.base import BaseParser
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://www.seiei.or.jp"
+LIST_URL = f"{BASE_URL}/iwate/yokujou.html"
+
+_DETAIL_HINT_PATTERN = re.compile(r"(yokujou|bath|sento|onsen)", re.IGNORECASE)
+_ADDR_TEXT_PATTERN = re.compile(r"住所\s*[:：]\s*([^\n\r]+)")
+_PHONE_TEXT_PATTERN = re.compile(r"(?:TEL|電話(?:番号)?)\s*[:：]\s*([0-9\-（）()\s]{8,})", re.IGNORECASE)
+_OPEN_HOURS_PATTERN = re.compile(r"(?:営業時間|営業)\s*[:：]\s*([^\n\r]+)")
+_HOLIDAY_PATTERN = re.compile(r"(?:定休日|休日)\s*[:：]\s*([^\n\r]+)")
+
+_GMAPS_Q_PATTERN = re.compile(r"[?&]q=([\-\d.]+),([\-\d.]+)")
+_GMAPS_LL_PATTERN = re.compile(r"[?&]ll=([\-\d.]+),([\-\d.]+)")
+_GMAPS_DESTINATION_PATTERN = re.compile(r"(?:destination|daddr)=([\-\d.]+),([\-\d.]+)")
+_GMAPS_AT_PATTERN = re.compile(r"@([\-\d.]+),([\-\d.]+)")
+_GMAPS_EMBED_PATTERN = re.compile(r"!3d([\-\d.]+)!.*!4d([\-\d.]+)")
+
+
+class IwateParser(BaseParser):
+    prefecture = "岩手県"
+    region = "東北"
+
+    def get_list_urls(self) -> list[str]:
+        return [LIST_URL]
+
+    def get_item_urls(self, html: str, page_url: str) -> list[str]:
+        soup = BeautifulSoup(html, "lxml")
+        urls: list[str] = []
+        seen: set[str] = set()
+
+        for a in soup.find_all("a", href=True):
+            raw_href: str = a["href"].strip()
+            if not raw_href or raw_href.startswith(("#", "mailto:", "tel:", "javascript:")):
+                continue
+            if raw_href.lower().endswith((".pdf", ".jpg", ".jpeg", ".png", ".gif")):
+                continue
+
+            href = urljoin(page_url, raw_href)
+            parsed = urlparse(href)
+            if "seiei.or.jp" not in parsed.netloc:
+                continue
+            if "/iwate/" not in parsed.path:
+                continue
+
+            # 一覧起点ページ自体は除外。詳細候補のみに絞る。
+            if href.rstrip("/") == LIST_URL.rstrip("/"):
+                continue
+
+            anchor_text = a.get_text(" ", strip=True)
+            if not _DETAIL_HINT_PATTERN.search(href) and not any(k in anchor_text for k in ("湯", "浴場", "銭湯", "温泉")):
+                continue
+
+            if href not in seen:
+                seen.add(href)
+                urls.append(href)
+
+        return urls
+
+    def parse_sento(self, html: str, page_url: str) -> Optional[dict]:
+        soup = BeautifulSoup(html, "lxml")
+
+        name = self._extract_name(soup)
+        address = self._extract_address(soup)
+
+        if not name or not address:
+            logger.warning("必須項目が取得できません: %s (name=%s, address=%s)", page_url, bool(name), bool(address))
+            return None
+
+        phone = self._extract_phone(soup)
+        open_hours = self._extract_open_hours(soup)
+        holiday = self._extract_holiday(soup)
+        lat, lng = self._extract_lat_lng(soup)
+
+        return self.make_sento_dict(
+            name=name,
+            address=address,
+            lat=lat,
+            lng=lng,
+            phone=phone,
+            open_hours=open_hours,
+            holiday=holiday,
+            source_url=page_url,
+            facility_type="sento",
+        )
+
+    @staticmethod
+    def _extract_name(soup: BeautifulSoup) -> Optional[str]:
+        for selector in ("h1", "h2", "h3", ".entry-title", ".page-title", "title"):
+            tag = soup.select_one(selector)
+            if not tag:
+                continue
+            raw = tag.get_text(" ", strip=True)
+            if not raw:
+                continue
+            cleaned = re.sub(r"\s*[|｜].*$", "", raw).strip()
+            if 1 <= len(cleaned) <= 80:
+                return cleaned
+        return None
+
+    def _extract_address(self, soup: BeautifulSoup) -> Optional[str]:
+        address = (
+            self.extract_label_value(soup, "住所")
+            or self.extract_table_value(soup, "住所")
+            or self._extract_from_text(soup, _ADDR_TEXT_PATTERN)
+        )
+        if not address:
+            return None
+
+        normalized = re.sub(r"\s+", " ", address).strip()
+        normalized = re.sub(r"^(?:〒\d{3}-\d{4}\s*)", "", normalized)
+        return normalized or None
+
+    def _extract_phone(self, soup: BeautifulSoup) -> Optional[str]:
+        phone = (
+            self.extract_label_value(soup, "TEL")
+            or self.extract_label_value(soup, "電話")
+            or self.extract_table_value(soup, "TEL")
+            or self.extract_table_value(soup, "電話")
+            or self._extract_from_text(soup, _PHONE_TEXT_PATTERN)
+        )
+        if not phone:
+            tel_tag = soup.find("a", href=re.compile(r"^tel:"))
+            if tel_tag:
+                phone = tel_tag["href"].replace("tel:", "").strip()
+
+        if not phone:
+            return None
+
+        normalized = re.sub(r"\s+", "", phone)
+        return normalized.strip("-") or None
+
+    def _extract_open_hours(self, soup: BeautifulSoup) -> Optional[str]:
+        return (
+            self.extract_label_value(soup, "営業時間")
+            or self.extract_table_value(soup, "営業時間")
+            or self._extract_from_text(soup, _OPEN_HOURS_PATTERN)
+        )
+
+    def _extract_holiday(self, soup: BeautifulSoup) -> Optional[str]:
+        return (
+            self.extract_label_value(soup, "定休日")
+            or self.extract_label_value(soup, "休日")
+            or self.extract_table_value(soup, "定休日")
+            or self.extract_table_value(soup, "休日")
+            or self._extract_from_text(soup, _HOLIDAY_PATTERN)
+        )
+
+    @staticmethod
+    def _extract_from_text(soup: BeautifulSoup, pattern: re.Pattern[str]) -> Optional[str]:
+        text = soup.get_text("\n", strip=True)
+        m = pattern.search(text)
+        if m:
+            value = m.group(1).strip()
+            return value if value else None
+        return None
+
+    def _extract_lat_lng(self, soup: BeautifulSoup) -> tuple[Optional[float], Optional[float]]:
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            if "google" not in href or "map" not in href:
+                continue
+            coords = self._extract_coords_from_url(href)
+            if coords is not None:
+                return coords
+
+        for iframe in soup.find_all("iframe", src=True):
+            src = iframe["src"]
+            if "google" not in src or "map" not in src:
+                continue
+            coords = self._extract_coords_from_url(src)
+            if coords is not None:
+                return coords
+
+        return None, None
+
+    @staticmethod
+    def _extract_coords_from_url(url: str) -> Optional[tuple[float, float]]:
+        for pattern in (
+            _GMAPS_Q_PATTERN,
+            _GMAPS_LL_PATTERN,
+            _GMAPS_DESTINATION_PATTERN,
+            _GMAPS_AT_PATTERN,
+            _GMAPS_EMBED_PATTERN,
+        ):
+            m = pattern.search(url)
+            if not m:
+                continue
+            try:
+                return float(m.group(1)), float(m.group(2))
+            except ValueError:
+                continue
+        return None

--- a/batch/parsers/iwate.py
+++ b/batch/parsers/iwate.py
@@ -3,6 +3,7 @@
 調査メモ:
 - 候補ドメイン `iwate-sento.com` / `iwate1010.jp` は有効な公開サイトを確認できず。
 - 公開検索で確認できた岩手県の公衆浴場組合関連ページを一覧起点にする。
+- TODO: https://www.seiei.or.jp/robots.txt と利用規約の確認を実施すること。
 
 実装方針:
 - 一覧ページから同一ドメイン内の詳細ページ URL を収集
@@ -24,6 +25,11 @@ BASE_URL = "https://www.seiei.or.jp"
 LIST_URL = f"{BASE_URL}/iwate/yokujou.html"
 
 _DETAIL_HINT_PATTERN = re.compile(r"(yokujou|bath|sento|onsen)", re.IGNORECASE)
+_EXCLUDED_PATH_PATTERN = re.compile(
+    r"(?:/iwate/(?:index|home|oshirase|news|topics|contact|privacy))|"
+    r"(?:/(?:contact|privacy)(?:[/-]|$))",
+    re.IGNORECASE,
+)
 _ADDR_TEXT_PATTERN = re.compile(r"住所\s*[:：]\s*([^\n\r]+)")
 _PHONE_TEXT_PATTERN = re.compile(r"(?:TEL|電話(?:番号)?)\s*[:：]\s*([0-9\-（）()\s]{8,})", re.IGNORECASE)
 _OPEN_HOURS_PATTERN = re.compile(r"(?:営業時間|営業)\s*[:：]\s*([^\n\r]+)")
@@ -61,13 +67,21 @@ class IwateParser(BaseParser):
                 continue
             if "/iwate/" not in parsed.path:
                 continue
+            if _EXCLUDED_PATH_PATTERN.search(parsed.path):
+                continue
 
             # 一覧起点ページ自体は除外。詳細候補のみに絞る。
             if href.rstrip("/") == LIST_URL.rstrip("/"):
                 continue
 
             anchor_text = a.get_text(" ", strip=True)
-            if not _DETAIL_HINT_PATTERN.search(href) and not any(k in anchor_text for k in ("湯", "浴場", "銭湯", "温泉")):
+            path = parsed.path.lower()
+            looks_like_detail_path = (
+                path.endswith(".html")
+                or "/yokujou/" in path
+                or _DETAIL_HINT_PATTERN.search(href) is not None
+            )
+            if not looks_like_detail_path and not any(k in anchor_text for k in ("湯", "浴場", "銭湯", "温泉")):
                 continue
 
             if href not in seen:
@@ -112,7 +126,15 @@ class IwateParser(BaseParser):
             raw = tag.get_text(" ", strip=True)
             if not raw:
                 continue
-            cleaned = re.sub(r"\s*[|｜].*$", "", raw).strip()
+            if selector == "title":
+                parts = [p.strip() for p in re.split(r"[|｜]", raw) if p.strip()]
+                if not parts:
+                    continue
+                # title が「サイト名 | 銭湯名」の順でも銭湯名を優先して拾う
+                sento_parts = [p for p in parts if any(k in p for k in ("湯", "浴場", "銭湯", "温泉"))]
+                cleaned = sento_parts[0] if sento_parts else parts[0]
+            else:
+                cleaned = re.sub(r"\s*[|｜].*$", "", raw).strip()
             if 1 <= len(cleaned) <= 80:
                 return cleaned
         return None

--- a/batch/tests/test_iwate_parser.py
+++ b/batch/tests/test_iwate_parser.py
@@ -23,6 +23,7 @@ IWATE_LIST_HTML = """
 <html><body>
   <a href="/iwate/yokujou/store-a.html">盛岡湯</a>
   <a href="https://www.seiei.or.jp/iwate/yokujou/store-b.html">花巻湯</a>
+  <a href="/iwate/store-c.html">施設C</a>
   <a href="/iwate/yokujou/store-a.html">盛岡湯(重複)</a>
   <a href="https://www.google.com/maps?q=39.7036,141.1527">外部地図（除外）</a>
   <a href="/iwate/oshirase.html">お知らせ（除外）</a>
@@ -36,7 +37,8 @@ def test_get_item_urls_extracts_detail_links(parser: IwateParser) -> None:
 
     assert "https://www.seiei.or.jp/iwate/yokujou/store-a.html" in urls
     assert "https://www.seiei.or.jp/iwate/yokujou/store-b.html" in urls
-    assert len(urls) == 2
+    assert "https://www.seiei.or.jp/iwate/store-c.html" in urls
+    assert len(urls) == 3
 
 
 IWATE_DETAIL_HTML_HAPPY = """
@@ -108,3 +110,24 @@ def test_parse_sento_returns_none_when_required_missing(parser: IwateParser) -> 
     )
 
     assert result is None
+
+
+IWATE_DETAIL_HTML_IFRAME_COORDS = """
+<html><body>
+  <h1>一関湯</h1>
+  <p>住所：岩手県一関市1-2-3</p>
+  <iframe src="https://www.google.com/maps/embed?pb=!1m18!...!3d38.9340!...!4d141.1300!..."></iframe>
+</body></html>
+"""
+
+
+def test_parse_sento_extracts_coords_from_iframe(parser: IwateParser) -> None:
+    result = parser.parse_sento(
+        IWATE_DETAIL_HTML_IFRAME_COORDS,
+        "https://www.seiei.or.jp/iwate/store-c.html",
+    )
+
+    assert result is not None
+    assert result["address"] == "岩手県一関市1-2-3"
+    assert result["lat"] == pytest.approx(38.9340)
+    assert result["lng"] == pytest.approx(141.1300)

--- a/batch/tests/test_iwate_parser.py
+++ b/batch/tests/test_iwate_parser.py
@@ -1,0 +1,110 @@
+"""IwateParser のユニットテスト。"""
+import pytest
+
+from parsers import PARSERS
+from parsers.iwate import IwateParser, LIST_URL
+
+
+@pytest.fixture
+def parser() -> IwateParser:
+    return IwateParser()
+
+
+def test_parsers_registry_contains_iwate() -> None:
+    assert "岩手県" in PARSERS
+    assert PARSERS["岩手県"] is IwateParser
+
+
+def test_get_list_urls(parser: IwateParser) -> None:
+    assert parser.get_list_urls() == [LIST_URL]
+
+
+IWATE_LIST_HTML = """
+<html><body>
+  <a href="/iwate/yokujou/store-a.html">盛岡湯</a>
+  <a href="https://www.seiei.or.jp/iwate/yokujou/store-b.html">花巻湯</a>
+  <a href="/iwate/yokujou/store-a.html">盛岡湯(重複)</a>
+  <a href="https://www.google.com/maps?q=39.7036,141.1527">外部地図（除外）</a>
+  <a href="/iwate/oshirase.html">お知らせ（除外）</a>
+  <a href="/iwate/yokujou.pdf">PDF（除外）</a>
+</body></html>
+"""
+
+
+def test_get_item_urls_extracts_detail_links(parser: IwateParser) -> None:
+    urls = parser.get_item_urls(IWATE_LIST_HTML, LIST_URL)
+
+    assert "https://www.seiei.or.jp/iwate/yokujou/store-a.html" in urls
+    assert "https://www.seiei.or.jp/iwate/yokujou/store-b.html" in urls
+    assert len(urls) == 2
+
+
+IWATE_DETAIL_HTML_HAPPY = """
+<html><body>
+  <h1>盛岡湯</h1>
+  <dl>
+    <dt>住所</dt><dd>岩手県盛岡市中央通1-2-3</dd>
+    <dt>TEL</dt><dd>019-123-4567</dd>
+    <dt>営業時間</dt><dd>14:00〜22:00</dd>
+    <dt>定休日</dt><dd>月曜日</dd>
+  </dl>
+  <a href="https://www.google.com/maps?q=39.7036,141.1527">地図</a>
+</body></html>
+"""
+
+
+def test_parse_sento_happy_path(parser: IwateParser) -> None:
+    url = "https://www.seiei.or.jp/iwate/yokujou/store-a.html"
+    result = parser.parse_sento(IWATE_DETAIL_HTML_HAPPY, url)
+
+    assert result is not None
+    assert result["name"] == "盛岡湯"
+    assert result["address"] == "岩手県盛岡市中央通1-2-3"
+    assert result["phone"] == "019-123-4567"
+    assert result["open_hours"] == "14:00〜22:00"
+    assert result["holiday"] == "月曜日"
+    assert result["lat"] == pytest.approx(39.7036)
+    assert result["lng"] == pytest.approx(141.1527)
+    assert result["prefecture"] == "岩手県"
+    assert result["region"] == "東北"
+    assert result["facility_type"] == "sento"
+    assert result["source_url"] == url
+
+
+IWATE_DETAIL_HTML_NO_COORDS = """
+<html><body>
+  <h1>花巻湯</h1>
+  <table>
+    <tr><th>住所</th><td>岩手県花巻市末広町4-5-6</td></tr>
+    <tr><th>電話</th><td>0198-12-3456</td></tr>
+  </table>
+</body></html>
+"""
+
+
+def test_parse_sento_without_coords_returns_none_lat_lng(parser: IwateParser) -> None:
+    result = parser.parse_sento(
+        IWATE_DETAIL_HTML_NO_COORDS,
+        "https://www.seiei.or.jp/iwate/yokujou/store-b.html",
+    )
+
+    assert result is not None
+    assert result["lat"] is None
+    assert result["lng"] is None
+
+
+IWATE_DETAIL_HTML_MISSING_REQUIRED = """
+<html><body>
+  <h1>見出しのみ</h1>
+  <p>住所情報がありません</p>
+</body></html>
+"""
+
+
+def test_parse_sento_returns_none_when_required_missing(parser: IwateParser) -> None:
+    result = parser.parse_sento(
+        IWATE_DETAIL_HTML_MISSING_REQUIRED,
+        "https://www.seiei.or.jp/iwate/yokujou/unknown.html",
+    )
+
+    assert result is None


### PR DESCRIPTION
## Summary
- `batch/parsers/iwate.py` 新規作成（BaseParser継承）
- seiei.or.jp/iwate の一覧・個別ページをスクレイピング
- Google Mapsリンクから座標抽出、なければOSM補完対象（lat/lng=None）
- `batch/parsers/__init__.py` に IwateParser を登録

## Test plan
- [x] `PARSERS["岩手県"]` に IwateParser が登録されていること
- [x] `get_list_urls()` が正しいURLを返すこと
- [x] `get_item_urls()` が詳細ページURLのみ抽出すること（お知らせ等除外）
- [x] `parse_sento()` で名前・住所・座標が取得できること
- [x] 座標なしの場合 lat/lng = None になること
- [x] 必須項目欠損時に None を返すこと（6テスト全パス）

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)