### PR TITLE
feat(EXPAND-miyagi): 宮城県銭湯パーサー実装

### DIFF
--- a/batch/parsers/__init__.py
+++ b/batch/parsers/__init__.py
@@ -10,6 +10,7 @@ from parsers.hyogo import HyogoParser
 from parsers.saitama import SaitamaParser
 from parsers.chiba import ChibaParser
 from parsers.hokkaido import HokkaidoParser
+from parsers.miyagi import MiyagiParser
 
 PARSERS: dict[str, type[BaseParser]] = {
     "東京都": TokyoParser,
@@ -22,10 +23,11 @@ PARSERS: dict[str, type[BaseParser]] = {
     "埼玉県": SaitamaParser,
     "千葉県": ChibaParser,
     "北海道": HokkaidoParser,
+    "宮城県": MiyagiParser,
 }
 
 __all__ = [
     "BaseParser", "TokyoParser", "KyotoParser", "FukuokaParser",
     "OsakaParser", "AichiParser", "KanagawaParser", "HyogoParser",
-    "SaitamaParser", "ChibaParser", "HokkaidoParser", "PARSERS",
+    "SaitamaParser", "ChibaParser", "HokkaidoParser", "MiyagiParser", "PARSERS",
 ]

--- a/batch/parsers/miyagi.py
+++ b/batch/parsers/miyagi.py
@@ -17,9 +17,10 @@ _POST_URL_PATTERN = re.compile(r"/\d{4}/\d{2}/\d{2}/")
 _GMAPS_Q_PATTERN = re.compile(r"[?&]q=([-\d.]+),([-\d.]+)")
 _GMAPS_LL_PATTERN = re.compile(r"[?&]ll=([-\d.]+),([-\d.]+)")
 _GMAPS_DEST_PATTERN = re.compile(r"[?&]destination=([-\d.]+),([-\d.]+)")
-_GMAPS_AT_PATTERN = re.compile(r"/@([-\d.]+),([-\d.]+),")
+_GMAPS_AT_PATTERN = re.compile(r"/@([-\d.]+),([-\d.]+)")
 _GMAPS_QUERY_PATTERN = re.compile(r"[?&]query=([-\d.]+),([-\d.]+)")
 _GMAPS_EMBED_PATTERN = re.compile(r"!3d([-\d.]+)!.*!4d([-\d.]+)")
+_GMAPS_EMBED_2D3D_PATTERN = re.compile(r"!2d([-\d.]+)!3d([-\d.]+)")
 _LIST_PATH_KEYWORDS = (
     "/category/",
     "/tag/",
@@ -103,7 +104,7 @@ class MiyagiParser(BaseParser):
             logger.warning("name が取得できません: %s", page_url)
             return None
 
-        address = self.extract_label_value(soup, "住所") or self.extract_table_value(soup, "住所") or ""
+        address = self.extract_label_value(soup, "住所") or self.extract_table_value(soup, "住所")
         if not address:
             logger.warning("address が取得できません: %s", page_url)
             return None
@@ -173,11 +174,16 @@ class MiyagiParser(BaseParser):
             _GMAPS_QUERY_PATTERN,
             _GMAPS_AT_PATTERN,
             _GMAPS_EMBED_PATTERN,
+            _GMAPS_EMBED_2D3D_PATTERN,
         ):
             matched = pattern.search(url)
             if matched:
                 try:
-                    return float(matched.group(1)), float(matched.group(2))
+                    first = float(matched.group(1))
+                    second = float(matched.group(2))
+                    if pattern is _GMAPS_EMBED_2D3D_PATTERN:
+                        return second, first
+                    return first, second
                 except ValueError:
                     continue
 
@@ -237,7 +243,7 @@ class MiyagiParser(BaseParser):
             return False
         if path in ("/about", "/contact", "/privacy-policy", "/sitemap"):
             return False
-        return len(path.strip("/").split("/")) >= 1
+        return False
 
     def _looks_like_sento_page(self, soup: BeautifulSoup) -> bool:
         text = soup.get_text(separator="\n")

--- a/batch/parsers/miyagi.py
+++ b/batch/parsers/miyagi.py
@@ -1,0 +1,244 @@
+"""宮城県銭湯組合 (miyagi1010.com) パーサー。"""
+import logging
+import re
+from typing import Optional
+from urllib.parse import parse_qs, urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+from parsers.base import BaseParser
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://miyagi1010.com"
+TOP_URL = f"{BASE_URL}/"
+
+_POST_URL_PATTERN = re.compile(r"/\d{4}/\d{2}/\d{2}/")
+_GMAPS_Q_PATTERN = re.compile(r"[?&]q=([-\d.]+),([-\d.]+)")
+_GMAPS_LL_PATTERN = re.compile(r"[?&]ll=([-\d.]+),([-\d.]+)")
+_GMAPS_DEST_PATTERN = re.compile(r"[?&]destination=([-\d.]+),([-\d.]+)")
+_GMAPS_AT_PATTERN = re.compile(r"/@([-\d.]+),([-\d.]+),")
+_GMAPS_QUERY_PATTERN = re.compile(r"[?&]query=([-\d.]+),([-\d.]+)")
+_GMAPS_EMBED_PATTERN = re.compile(r"!3d([-\d.]+)!.*!4d([-\d.]+)")
+_LIST_PATH_KEYWORDS = (
+    "/category/",
+    "/tag/",
+    "/author/",
+    "/page/",
+    "/news/",
+    "/blog/",
+    "/archives/",
+)
+_SENTO_PAGE_HINTS = ("住所", "営業時間", "定休日", "電話", "TEL")
+
+
+class MiyagiParser(BaseParser):
+    prefecture = "宮城県"
+    region = "東北"
+
+    def get_list_urls(self) -> list[str]:
+        return [TOP_URL]
+
+    def get_all_list_urls(self, page1_html: str) -> list[str]:
+        """トップページ HTML から一覧ページ候補を収集する。"""
+        soup = BeautifulSoup(page1_html, "lxml")
+        urls: list[str] = [TOP_URL]
+        seen: set[str] = {TOP_URL}
+
+        for a in soup.find_all("a", href=True):
+            href = self._normalize_href(a["href"])
+            if not href or not self._is_internal_url(href):
+                continue
+
+            text = a.get_text(" ", strip=True)
+            if not self._is_list_like_url(href, text):
+                continue
+
+            if href not in seen:
+                seen.add(href)
+                urls.append(href)
+
+        return urls
+
+    def get_item_urls(self, html: str, page_url: str) -> list[str]:
+        """一覧ページから銭湯個別ページ URL を抽出する。"""
+        soup = BeautifulSoup(html, "lxml")
+        urls: list[str] = []
+        seen: set[str] = set()
+
+        for a in soup.select("article a[href], .post a[href], .entry a[href], h2 a[href], h3 a[href]"):
+            href = self._normalize_href(a.get("href", ""))
+            if href and self._is_sento_detail_url(href) and href not in seen:
+                seen.add(href)
+                urls.append(href)
+
+        if urls:
+            return urls
+
+        for a in soup.find_all("a", href=True):
+            href = self._normalize_href(a["href"])
+            if href and self._is_sento_detail_url(href) and href not in seen:
+                seen.add(href)
+                urls.append(href)
+
+        return urls
+
+    def parse_sento(self, html: str, page_url: str) -> Optional[dict]:
+        soup = BeautifulSoup(html, "lxml")
+
+        if self._is_list_like_url(page_url, "") and not self._looks_like_sento_page(soup):
+            return None
+
+        name: Optional[str] = None
+        for selector in ("h1.entry-title", "h1.post-title", ".entry-title", "h1", "h2"):
+            tag = soup.select_one(selector)
+            if not tag:
+                continue
+            raw = tag.get_text(strip=True)
+            if raw and len(raw) < 80:
+                name = raw
+                break
+
+        if not name:
+            logger.warning("name が取得できません: %s", page_url)
+            return None
+
+        address = self.extract_label_value(soup, "住所") or self.extract_table_value(soup, "住所") or ""
+        if not address:
+            logger.warning("address が取得できません: %s", page_url)
+            return None
+
+        phone = (
+            self.extract_label_value(soup, "TEL")
+            or self.extract_label_value(soup, "電話")
+            or self.extract_table_value(soup, "TEL")
+            or self.extract_table_value(soup, "電話")
+        )
+        if not phone:
+            tel_tag = soup.find("a", href=re.compile(r"^tel:"))
+            if tel_tag:
+                phone = tel_tag["href"].replace("tel:", "").strip()
+
+        open_hours = self.extract_label_value(soup, "営業時間") or self.extract_table_value(soup, "営業時間")
+        holiday = (
+            self.extract_label_value(soup, "定休日")
+            or self.extract_label_value(soup, "休日")
+            or self.extract_table_value(soup, "定休日")
+            or self.extract_table_value(soup, "休業日")
+            or self.extract_table_value(soup, "休日")
+        )
+
+        lat, lng = self._extract_coordinates(soup)
+
+        return {
+            **self.make_sento_dict(
+                name=name,
+                address=address,
+                lat=lat,
+                lng=lng,
+                phone=phone,
+                open_hours=open_hours,
+                holiday=holiday,
+                source_url=page_url,
+            ),
+            "facility_type": "sento",
+        }
+
+    def _extract_coordinates(self, soup: BeautifulSoup) -> tuple[Optional[float], Optional[float]]:
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            if "google.com/maps" not in href and "maps.app.goo.gl" not in href:
+                continue
+
+            coords = self._extract_coordinates_from_url(href)
+            if coords is not None:
+                return coords
+
+        for iframe in soup.find_all("iframe", src=True):
+            src = iframe["src"]
+            if "google.com/maps" not in src and "maps.google.com" not in src:
+                continue
+
+            coords = self._extract_coordinates_from_url(src)
+            if coords is not None:
+                return coords
+
+        return None, None
+
+    def _extract_coordinates_from_url(self, url: str) -> Optional[tuple[float, float]]:
+        for pattern in (
+            _GMAPS_Q_PATTERN,
+            _GMAPS_LL_PATTERN,
+            _GMAPS_DEST_PATTERN,
+            _GMAPS_QUERY_PATTERN,
+            _GMAPS_AT_PATTERN,
+            _GMAPS_EMBED_PATTERN,
+        ):
+            matched = pattern.search(url)
+            if matched:
+                try:
+                    return float(matched.group(1)), float(matched.group(2))
+                except ValueError:
+                    continue
+
+        parsed = urlparse(url)
+        query = parse_qs(parsed.query)
+        for key in ("q", "ll", "query", "destination"):
+            value = query.get(key, [])
+            if not value:
+                continue
+            parts = value[0].split(",")
+            if len(parts) != 2:
+                continue
+            try:
+                return float(parts[0]), float(parts[1])
+            except ValueError:
+                continue
+
+        return None
+
+    def _normalize_href(self, href: str) -> Optional[str]:
+        if not href or href.startswith("#"):
+            return None
+        normalized = href.strip()
+        if not normalized.startswith("http"):
+            normalized = urljoin(BASE_URL, normalized)
+        return normalized.rstrip("/")
+
+    def _is_internal_url(self, url: str) -> bool:
+        netloc = urlparse(url).netloc.lower()
+        return netloc in {"miyagi1010.com", "www.miyagi1010.com"}
+
+    def _is_list_like_url(self, href: str, text: str) -> bool:
+        parsed = urlparse(href)
+        lowered_text = text.lower()
+
+        if any(keyword in parsed.path for keyword in _LIST_PATH_KEYWORDS):
+            return True
+        if any(token in lowered_text for token in ("一覧", "エリア", "search", "カテゴリ", "銭湯")):
+            return True
+        if "cat" in parse_qs(parsed.query):
+            return True
+        return False
+
+    def _is_sento_detail_url(self, url: str) -> bool:
+        if not self._is_internal_url(url):
+            return False
+
+        parsed = urlparse(url)
+        path = parsed.path.lower()
+        if any(token in path for token in ("/wp-admin", "/wp-login", "/wp-json", "/feed")):
+            return False
+        if any(keyword in path for keyword in _LIST_PATH_KEYWORDS):
+            return False
+        if _POST_URL_PATTERN.search(path):
+            return True
+        if path in ("", "/"):
+            return False
+        if path in ("/about", "/contact", "/privacy-policy", "/sitemap"):
+            return False
+        return len(path.strip("/").split("/")) >= 1
+
+    def _looks_like_sento_page(self, soup: BeautifulSoup) -> bool:
+        text = soup.get_text(separator="\n")
+        return sum(1 for hint in _SENTO_PAGE_HINTS if hint in text) >= 2

--- a/batch/tests/test_miyagi_parser.py
+++ b/batch/tests/test_miyagi_parser.py
@@ -1,0 +1,121 @@
+"""MiyagiParser のユニットテスト。"""
+import pytest
+
+from parsers import PARSERS
+from parsers.miyagi import MiyagiParser
+
+
+@pytest.fixture
+def parser() -> MiyagiParser:
+    return MiyagiParser()
+
+
+MIYAGI_TOP_HTML = """
+<html>
+<body>
+  <a href="https://miyagi1010.com/category/sento/">銭湯一覧</a>
+  <a href="/category/news/">お知らせ</a>
+  <a href="https://example.com/category/sento/">外部</a>
+</body>
+</html>
+"""
+
+
+MIYAGI_LIST_HTML = """
+<html>
+<body>
+  <article><h2><a href="https://miyagi1010.com/2025/01/10/aoba-yu/">青葉湯</a></h2></article>
+  <article><h2><a href="/2025/02/01/sendai-yu/">仙台湯</a></h2></article>
+  <a href="https://miyagi1010.com/category/sento/">一覧（除外）</a>
+  <a href="https://miyagi1010.com/wp-admin/">管理（除外）</a>
+</body>
+</html>
+"""
+
+
+MIYAGI_DETAIL_HTML_HAPPY = """
+<html>
+<body>
+  <h1 class="entry-title">青葉湯</h1>
+  <dl>
+    <dt>住所</dt><dd>宮城県仙台市青葉区1-2-3</dd>
+    <dt>TEL</dt><dd>022-123-4567</dd>
+    <dt>営業時間</dt><dd>15:00〜23:00</dd>
+    <dt>定休日</dt><dd>月曜日</dd>
+  </dl>
+  <a href="https://www.google.com/maps?q=38.2682,140.8694">地図</a>
+</body>
+</html>
+"""
+
+
+MIYAGI_DETAIL_HTML_NO_COORD = """
+<html>
+<body>
+  <h1>榴岡湯</h1>
+  <table>
+    <tr><th>住所</th><td>宮城県仙台市宮城野区2-3-4</td></tr>
+    <tr><th>電話</th><td>022-987-6543</td></tr>
+  </table>
+</body>
+</html>
+"""
+
+
+MIYAGI_DETAIL_HTML_NO_NAME = """
+<html>
+<body>
+  <dl><dt>住所</dt><dd>宮城県仙台市若林区3-4-5</dd></dl>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_happy_path(parser: MiyagiParser) -> None:
+    result = parser.parse_sento(MIYAGI_DETAIL_HTML_HAPPY, "https://miyagi1010.com/2025/01/10/aoba-yu/")
+
+    assert result is not None
+    assert result["name"] == "青葉湯"
+    assert result["address"] == "宮城県仙台市青葉区1-2-3"
+    assert result["phone"] == "022-123-4567"
+    assert result["open_hours"] == "15:00〜23:00"
+    assert result["holiday"] == "月曜日"
+    assert result["lat"] == pytest.approx(38.2682)
+    assert result["lng"] == pytest.approx(140.8694)
+    assert result["prefecture"] == "宮城県"
+    assert result["region"] == "東北"
+    assert result["facility_type"] == "sento"
+
+
+def test_parse_sento_returns_none_when_name_missing(parser: MiyagiParser) -> None:
+    result = parser.parse_sento(MIYAGI_DETAIL_HTML_NO_NAME, "https://miyagi1010.com/2025/01/10/unknown/")
+    assert result is None
+
+
+def test_parse_sento_without_coordinates(parser: MiyagiParser) -> None:
+    result = parser.parse_sento(MIYAGI_DETAIL_HTML_NO_COORD, "https://miyagi1010.com/2025/02/11/tsutsujigaoka-yu/")
+    assert result is not None
+    assert result["lat"] is None
+    assert result["lng"] is None
+    assert result["address"] == "宮城県仙台市宮城野区2-3-4"
+
+
+def test_get_all_list_urls_collects_list_pages(parser: MiyagiParser) -> None:
+    urls = parser.get_all_list_urls(MIYAGI_TOP_HTML)
+    assert "https://miyagi1010.com/" in urls
+    assert "https://miyagi1010.com/category/sento" in urls
+    assert "https://miyagi1010.com/category/news" in urls
+    assert all("example.com" not in url for url in urls)
+
+
+def test_get_item_urls_extracts_detail_urls(parser: MiyagiParser) -> None:
+    urls = parser.get_item_urls(MIYAGI_LIST_HTML, "https://miyagi1010.com/category/sento/")
+    assert "https://miyagi1010.com/2025/01/10/aoba-yu" in urls
+    assert "https://miyagi1010.com/2025/02/01/sendai-yu" in urls
+    assert all("/category/" not in url for url in urls)
+    assert all("/wp-admin" not in url for url in urls)
+
+
+def test_parsers_contains_miyagi() -> None:
+    assert "宮城県" in PARSERS
+    assert PARSERS["宮城県"] is MiyagiParser

--- a/batch/tests/test_miyagi_parser.py
+++ b/batch/tests/test_miyagi_parser.py
@@ -1,5 +1,6 @@
 """MiyagiParser のユニットテスト。"""
 import pytest
+from bs4 import BeautifulSoup
 
 from parsers import PARSERS
 from parsers.miyagi import MiyagiParser
@@ -71,6 +72,27 @@ MIYAGI_DETAIL_HTML_NO_NAME = """
 """
 
 
+MIYAGI_DETAIL_HTML_NO_ADDRESS = """
+<html>
+<body>
+  <h1>青葉湯</h1>
+  <dl><dt>TEL</dt><dd>022-000-0000</dd></dl>
+</body>
+</html>
+"""
+
+
+MIYAGI_DETAIL_HTML_IFRAME_COORD = """
+<html>
+<body>
+  <h1>泉湯</h1>
+  <dl><dt>住所</dt><dd>宮城県仙台市泉区4-5-6</dd></dl>
+  <iframe src="https://www.google.com/maps/embed?pb=!1m18!2d140.881!3d38.301"></iframe>
+</body>
+</html>
+"""
+
+
 def test_parse_sento_happy_path(parser: MiyagiParser) -> None:
     result = parser.parse_sento(MIYAGI_DETAIL_HTML_HAPPY, "https://miyagi1010.com/2025/01/10/aoba-yu/")
 
@@ -92,12 +114,24 @@ def test_parse_sento_returns_none_when_name_missing(parser: MiyagiParser) -> Non
     assert result is None
 
 
+def test_parse_sento_returns_none_when_address_missing(parser: MiyagiParser) -> None:
+    result = parser.parse_sento(MIYAGI_DETAIL_HTML_NO_ADDRESS, "https://miyagi1010.com/2025/01/10/aoba-yu/")
+    assert result is None
+
+
 def test_parse_sento_without_coordinates(parser: MiyagiParser) -> None:
     result = parser.parse_sento(MIYAGI_DETAIL_HTML_NO_COORD, "https://miyagi1010.com/2025/02/11/tsutsujigaoka-yu/")
     assert result is not None
     assert result["lat"] is None
     assert result["lng"] is None
     assert result["address"] == "宮城県仙台市宮城野区2-3-4"
+
+
+def test_parse_sento_extracts_coordinates_from_iframe(parser: MiyagiParser) -> None:
+    result = parser.parse_sento(MIYAGI_DETAIL_HTML_IFRAME_COORD, "https://miyagi1010.com/2025/03/01/izumi-yu/")
+    assert result is not None
+    assert result["lat"] == pytest.approx(38.301)
+    assert result["lng"] == pytest.approx(140.881)
 
 
 def test_get_all_list_urls_collects_list_pages(parser: MiyagiParser) -> None:
@@ -114,6 +148,18 @@ def test_get_item_urls_extracts_detail_urls(parser: MiyagiParser) -> None:
     assert "https://miyagi1010.com/2025/02/01/sendai-yu" in urls
     assert all("/category/" not in url for url in urls)
     assert all("/wp-admin" not in url for url in urls)
+
+
+def test_looks_like_sento_page(parser: MiyagiParser) -> None:
+    html = "<html><body><p>住所</p><p>営業時間</p></body></html>"
+    soup = BeautifulSoup(html, "lxml")
+    assert parser._looks_like_sento_page(soup) is True
+
+
+def test_looks_like_sento_page_false_when_hints_are_insufficient(parser: MiyagiParser) -> None:
+    html = "<html><body><p>住所</p></body></html>"
+    soup = BeautifulSoup(html, "lxml")
+    assert parser._looks_like_sento_page(soup) is False
 
 
 def test_parsers_contains_miyagi() -> None:


### PR DESCRIPTION
## Summary
- `batch/parsers/miyagi.py` 新規作成（WordPress対応・chiba.pyパターン準拠）
- miyagi1010.com の一覧・個別ページをスクレイピング
- Google Mapsリンクから座標抽出

## Test plan
- [x] `PARSERS["宮城県"]` に MiyagiParser が登録されていること
- [x] WordPress 一覧ページから詳細URLを抽出できること
- [x] 正常系: name/address/座標が取得できること
- [x] 座標なしの場合 lat/lng = None になること
- [x] 必須項目欠損時に None を返すこと（6テスト全パス）

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)