### PR TITLE
feat(EXPAND-akita): 秋田県銭湯パーサー実装

### DIFF
--- a/batch/parsers/__init__.py
+++ b/batch/parsers/__init__.py
@@ -10,6 +10,7 @@ from parsers.hyogo import HyogoParser
 from parsers.saitama import SaitamaParser
 from parsers.chiba import ChibaParser
 from parsers.hokkaido import HokkaidoParser
+from parsers.akita import AkitaParser
 
 PARSERS: dict[str, type[BaseParser]] = {
     "東京都": TokyoParser,
@@ -22,10 +23,11 @@ PARSERS: dict[str, type[BaseParser]] = {
     "埼玉県": SaitamaParser,
     "千葉県": ChibaParser,
     "北海道": HokkaidoParser,
+    "秋田県": AkitaParser,
 }
 
 __all__ = [
     "BaseParser", "TokyoParser", "KyotoParser", "FukuokaParser",
     "OsakaParser", "AichiParser", "KanagawaParser", "HyogoParser",
-    "SaitamaParser", "ChibaParser", "HokkaidoParser", "PARSERS",
+    "SaitamaParser", "ChibaParser", "HokkaidoParser", "AkitaParser", "PARSERS",
 ]

--- a/batch/parsers/akita.py
+++ b/batch/parsers/akita.py
@@ -5,7 +5,7 @@
 import logging
 import re
 from typing import Optional
-from urllib.parse import urljoin, urlparse
+from urllib.parse import parse_qs, urljoin, urlparse
 
 from bs4 import BeautifulSoup
 
@@ -33,6 +33,7 @@ _GMAPS_DEST_PATTERN = re.compile(r"[?&]destination=([-\d.]+),([-\d.]+)")
 _GMAPS_LL_PATTERN = re.compile(r"[?&]ll=([-\d.]+),([-\d.]+)")
 _GMAPS_AT_PATTERN = re.compile(r"/@([-\d.]+),([-\d.]+)")
 _GMAPS_EMBED_PATTERN = re.compile(r"!3d([-\d.]+)!.*!4d([-\d.]+)")
+_GMAPS_EMBED_2D3D_PATTERN = re.compile(r"!2d([-\d.]+)!3d([-\d.]+)")
 
 
 class AkitaParser(BaseParser):
@@ -101,8 +102,11 @@ class AkitaParser(BaseParser):
         address = (
             self.extract_label_value(soup, "住所")
             or self.extract_table_value(soup, "住所")
-            or (soup.find("address").get_text(" ", strip=True) if soup.find("address") else "")
+            or (soup.find("address").get_text(" ", strip=True) if soup.find("address") else None)
         )
+        if not address:
+            logger.warning("address が取得できません: %s", page_url)
+            return None
 
         phone = (
             self.extract_label_value(soup, "TEL")
@@ -135,24 +139,9 @@ class AkitaParser(BaseParser):
             href = str(tag["href"])
             if "google." not in href or "/maps" not in href:
                 continue
-            for pat in (
-                _GMAPS_Q_PATTERN,
-                _GMAPS_QUERY_PATTERN,
-                _GMAPS_DEST_PATTERN,
-                _GMAPS_LL_PATTERN,
-                _GMAPS_AT_PATTERN,
-            ):
-                m = pat.search(href)
-                if not m:
-                    continue
-                try:
-                    lat = float(m.group(1))
-                    lng = float(m.group(2))
-                except ValueError:
-                    lat = None
-                    lng = None
-                break
-            if lat is not None:
+            coords = self._extract_coordinates_from_url(href)
+            if coords is not None:
+                lat, lng = coords
                 break
 
         if lat is None:
@@ -160,16 +149,9 @@ class AkitaParser(BaseParser):
                 src = str(iframe["src"])
                 if "google." not in src or "/maps" not in src:
                     continue
-                m = _GMAPS_EMBED_PATTERN.search(src)
-                if not m:
-                    continue
-                try:
-                    lat = float(m.group(1))
-                    lng = float(m.group(2))
-                except ValueError:
-                    lat = None
-                    lng = None
-                if lat is not None:
+                coords = self._extract_coordinates_from_url(src)
+                if coords is not None:
+                    lat, lng = coords
                     break
 
         return self.make_sento_dict(
@@ -183,3 +165,41 @@ class AkitaParser(BaseParser):
             source_url=page_url,
             facility_type="sento",
         )
+
+    def _extract_coordinates_from_url(self, url: str) -> Optional[tuple[float, float]]:
+        for pat in (
+            _GMAPS_Q_PATTERN,
+            _GMAPS_QUERY_PATTERN,
+            _GMAPS_DEST_PATTERN,
+            _GMAPS_LL_PATTERN,
+            _GMAPS_AT_PATTERN,
+            _GMAPS_EMBED_PATTERN,
+            _GMAPS_EMBED_2D3D_PATTERN,
+        ):
+            m = pat.search(url)
+            if not m:
+                continue
+            try:
+                first = float(m.group(1))
+                second = float(m.group(2))
+                if pat is _GMAPS_EMBED_2D3D_PATTERN:
+                    return second, first
+                return first, second
+            except ValueError:
+                continue
+
+        parsed = urlparse(url)
+        query = parse_qs(parsed.query)
+        for key in ("q", "ll", "query", "destination"):
+            value = query.get(key, [])
+            if not value:
+                continue
+            parts = value[0].split(",")
+            if len(parts) != 2:
+                continue
+            try:
+                return float(parts[0]), float(parts[1])
+            except ValueError:
+                continue
+
+        return None

--- a/batch/parsers/akita.py
+++ b/batch/parsers/akita.py
@@ -1,0 +1,185 @@
+"""秋田県銭湯 (akita-sento.com) パーサー。
+
+静的 HTML サイトを前提に BeautifulSoup のみで抽出する。
+"""
+import logging
+import re
+from typing import Optional
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+from parsers.base import BaseParser
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://akita-sento.com"
+LIST_URLS = [
+    f"{BASE_URL}/",
+    f"{BASE_URL}/sento/",
+]
+
+_DETAIL_URL_PATTERNS = [
+    re.compile(r"/sento/[^/?#]+/?$"),
+    re.compile(r"/bath/[^/?#]+/?$"),
+    re.compile(r"/shop/[^/?#]+/?$"),
+    re.compile(r"/facility/[^/?#]+/?$"),
+]
+_LIST_OR_INDEX_HINTS = ("/category/", "/tag/", "/author/", "/page/", "/news/", "/blog/")
+
+_GMAPS_Q_PATTERN = re.compile(r"[?&]q=([-\d.]+),([-\d.]+)")
+_GMAPS_QUERY_PATTERN = re.compile(r"[?&]query=([-\d.]+),([-\d.]+)")
+_GMAPS_DEST_PATTERN = re.compile(r"[?&]destination=([-\d.]+),([-\d.]+)")
+_GMAPS_LL_PATTERN = re.compile(r"[?&]ll=([-\d.]+),([-\d.]+)")
+_GMAPS_AT_PATTERN = re.compile(r"/@([-\d.]+),([-\d.]+)")
+_GMAPS_EMBED_PATTERN = re.compile(r"!3d([-\d.]+)!.*!4d([-\d.]+)")
+
+
+class AkitaParser(BaseParser):
+    prefecture = "秋田県"
+    region = "東北"
+
+    def get_list_urls(self) -> list[str]:
+        return LIST_URLS
+
+    def get_item_urls(self, html: str, page_url: str) -> list[str]:
+        soup = BeautifulSoup(html, "lxml")
+        urls: list[str] = []
+        seen: set[str] = set()
+
+        for a in soup.find_all("a", href=True):
+            href: str = a["href"].strip()
+            if not href:
+                continue
+
+            if not href.startswith("http"):
+                href = urljoin(BASE_URL, href)
+
+            parsed = urlparse(href)
+            if "akita-sento.com" not in parsed.netloc:
+                continue
+
+            path = parsed.path or "/"
+            if path in ("/", "/sento/"):
+                continue
+            if any(hint in path for hint in _LIST_OR_INDEX_HINTS):
+                continue
+
+            if any(pat.search(path) for pat in _DETAIL_URL_PATTERNS):
+                if href not in seen:
+                    seen.add(href)
+                    urls.append(href)
+
+        logger.info("秋田一覧: %d 件取得", len(urls))
+        return urls
+
+    def parse_sento(self, html: str, page_url: str) -> Optional[dict]:
+        soup = BeautifulSoup(html, "lxml")
+
+        name: Optional[str] = None
+        for selector in (
+            "h1.entry-title",
+            "h1.post-title",
+            "h1.page-title",
+            ".sento-name",
+            "main h1",
+            "h1",
+            "h2",
+        ):
+            tag = soup.select_one(selector)
+            if not tag:
+                continue
+            raw = tag.get_text(strip=True)
+            if raw and len(raw) < 80:
+                name = raw
+                break
+
+        if not name:
+            logger.warning("name が取得できません: %s", page_url)
+            return None
+
+        address = (
+            self.extract_label_value(soup, "住所")
+            or self.extract_table_value(soup, "住所")
+            or (soup.find("address").get_text(" ", strip=True) if soup.find("address") else "")
+        )
+
+        phone = (
+            self.extract_label_value(soup, "TEL")
+            or self.extract_label_value(soup, "電話")
+            or self.extract_table_value(soup, "TEL")
+            or self.extract_table_value(soup, "電話")
+        )
+        if not phone:
+            tel_tag = soup.find("a", href=re.compile(r"^tel:"))
+            if tel_tag:
+                phone = str(tel_tag["href"]).replace("tel:", "").strip()
+
+        open_hours = (
+            self.extract_label_value(soup, "営業時間")
+            or self.extract_label_value(soup, "営業時刻")
+            or self.extract_table_value(soup, "営業時間")
+        )
+        holiday = (
+            self.extract_label_value(soup, "定休日")
+            or self.extract_label_value(soup, "休業日")
+            or self.extract_label_value(soup, "休日")
+            or self.extract_table_value(soup, "定休日")
+            or self.extract_table_value(soup, "休業日")
+        )
+
+        lat: Optional[float] = None
+        lng: Optional[float] = None
+
+        for tag in soup.find_all("a", href=True):
+            href = str(tag["href"])
+            if "google." not in href or "/maps" not in href:
+                continue
+            for pat in (
+                _GMAPS_Q_PATTERN,
+                _GMAPS_QUERY_PATTERN,
+                _GMAPS_DEST_PATTERN,
+                _GMAPS_LL_PATTERN,
+                _GMAPS_AT_PATTERN,
+            ):
+                m = pat.search(href)
+                if not m:
+                    continue
+                try:
+                    lat = float(m.group(1))
+                    lng = float(m.group(2))
+                except ValueError:
+                    lat = None
+                    lng = None
+                break
+            if lat is not None:
+                break
+
+        if lat is None:
+            for iframe in soup.find_all("iframe", src=True):
+                src = str(iframe["src"])
+                if "google." not in src or "/maps" not in src:
+                    continue
+                m = _GMAPS_EMBED_PATTERN.search(src)
+                if not m:
+                    continue
+                try:
+                    lat = float(m.group(1))
+                    lng = float(m.group(2))
+                except ValueError:
+                    lat = None
+                    lng = None
+                if lat is not None:
+                    break
+
+        return self.make_sento_dict(
+            name=name,
+            address=address,
+            lat=lat,
+            lng=lng,
+            phone=phone,
+            open_hours=open_hours,
+            holiday=holiday,
+            source_url=page_url,
+            facility_type="sento",
+        )

--- a/batch/tests/test_akita_parser.py
+++ b/batch/tests/test_akita_parser.py
@@ -115,6 +115,55 @@ def test_parse_sento_returns_none_when_name_missing(parser: AkitaParser) -> None
     assert result is None
 
 
+AKITA_DETAIL_HTML_NO_ADDRESS = """
+<html>
+<body>
+  <h1>秋田温泉</h1>
+  <p>住所情報なし</p>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_returns_none_when_address_missing(parser: AkitaParser) -> None:
+    result = parser.parse_sento(AKITA_DETAIL_HTML_NO_ADDRESS, "https://akita-sento.com/sento/no-address/")
+    assert result is None
+
+
+AKITA_DETAIL_HTML_ADDRESS_TAG = """
+<html>
+<body>
+  <h1>川反の湯</h1>
+  <address>秋田県秋田市川反町 1-2-3</address>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_falls_back_to_address_tag(parser: AkitaParser) -> None:
+    result = parser.parse_sento(AKITA_DETAIL_HTML_ADDRESS_TAG, "https://akita-sento.com/sento/kawabata/")
+    assert result is not None
+    assert result["address"] == "秋田県秋田市川反町 1-2-3"
+
+
+AKITA_DETAIL_HTML_IFRAME_Q = """
+<html>
+<body>
+  <h1>土崎の湯</h1>
+  <dl><dt>住所</dt><dd>秋田県秋田市土崎港1-2-3</dd></dl>
+  <iframe src="https://www.google.com/maps?q=39.7501,140.0701"></iframe>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_coords_from_iframe_q(parser: AkitaParser) -> None:
+    result = parser.parse_sento(AKITA_DETAIL_HTML_IFRAME_Q, "https://akita-sento.com/sento/tsuchizaki/")
+    assert result is not None
+    assert result["lat"] == pytest.approx(39.7501)
+    assert result["lng"] == pytest.approx(140.0701)
+
+
 AKITA_LIST_HTML = """
 <html>
 <body>

--- a/batch/tests/test_akita_parser.py
+++ b/batch/tests/test_akita_parser.py
@@ -1,0 +1,149 @@
+"""AkitaParser のユニットテスト。"""
+import pytest
+
+from parsers import PARSERS
+from parsers.akita import AkitaParser
+
+
+@pytest.fixture
+def parser() -> AkitaParser:
+    return AkitaParser()
+
+
+AKITA_DETAIL_HTML_HAPPY = """
+<html>
+<body>
+  <h1 class="entry-title">秋田温泉</h1>
+  <dl>
+    <dt>住所</dt><dd>秋田県秋田市1-2-3</dd>
+    <dt>TEL</dt><dd>018-123-4567</dd>
+    <dt>営業時間</dt><dd>15:00〜22:30</dd>
+    <dt>定休日</dt><dd>月曜日</dd>
+  </dl>
+  <a href="https://www.google.com/maps?q=39.7199,140.1025">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_happy_path(parser: AkitaParser) -> None:
+    result = parser.parse_sento(AKITA_DETAIL_HTML_HAPPY, "https://akita-sento.com/sento/akita-onsen/")
+    assert result is not None
+    assert result["name"] == "秋田温泉"
+    assert result["address"] == "秋田県秋田市1-2-3"
+    assert result["phone"] == "018-123-4567"
+    assert result["open_hours"] == "15:00〜22:30"
+    assert result["holiday"] == "月曜日"
+    assert result["lat"] == pytest.approx(39.7199)
+    assert result["lng"] == pytest.approx(140.1025)
+    assert result["prefecture"] == "秋田県"
+    assert result["region"] == "東北"
+    assert result["facility_type"] == "sento"
+
+
+AKITA_DETAIL_HTML_TABLE_AND_AT = """
+<html>
+<body>
+  <h1>港の湯</h1>
+  <table>
+    <tr><th>住所</th><td>秋田県秋田市港2-3-4</td></tr>
+    <tr><th>電話</th><td>018-222-3333</td></tr>
+    <tr><th>休業日</th><td>第2火曜日</td></tr>
+  </table>
+  <a href="https://www.google.com/maps/place/%E6%B8%AF/@39.7000,140.1200,17z">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_table_and_at_coords(parser: AkitaParser) -> None:
+    result = parser.parse_sento(AKITA_DETAIL_HTML_TABLE_AND_AT, "https://akita-sento.com/sento/minato/")
+    assert result is not None
+    assert result["address"] == "秋田県秋田市港2-3-4"
+    assert result["phone"] == "018-222-3333"
+    assert result["holiday"] == "第2火曜日"
+    assert result["lat"] == pytest.approx(39.7000)
+    assert result["lng"] == pytest.approx(140.1200)
+
+
+AKITA_DETAIL_HTML_IFRAME = """
+<html>
+<body>
+  <h2>旭湯</h2>
+  <dl>
+    <dt>住所</dt><dd>秋田県横手市5-6-7</dd>
+  </dl>
+  <iframe src="https://www.google.com/maps/embed?pb=!1m18!...!3d39.3100!...!4d140.5600!..."></iframe>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_coords_from_iframe(parser: AkitaParser) -> None:
+    result = parser.parse_sento(AKITA_DETAIL_HTML_IFRAME, "https://akita-sento.com/sento/asahi/")
+    assert result is not None
+    assert result["lat"] == pytest.approx(39.3100)
+    assert result["lng"] == pytest.approx(140.5600)
+
+
+AKITA_DETAIL_HTML_NO_COORDS = """
+<html>
+<body>
+  <h1>白神の湯</h1>
+  <dl>
+    <dt>住所</dt><dd>秋田県能代市8-9-10</dd>
+  </dl>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_lat_lng_none_when_no_maps_link(parser: AkitaParser) -> None:
+    result = parser.parse_sento(AKITA_DETAIL_HTML_NO_COORDS, "https://akita-sento.com/sento/shirakami/")
+    assert result is not None
+    assert result["lat"] is None
+    assert result["lng"] is None
+
+
+AKITA_DETAIL_HTML_NO_NAME = """
+<html><body><p>銭湯情報なし</p></body></html>
+"""
+
+
+def test_parse_sento_returns_none_when_name_missing(parser: AkitaParser) -> None:
+    result = parser.parse_sento(AKITA_DETAIL_HTML_NO_NAME, "https://akita-sento.com/sento/unknown/")
+    assert result is None
+
+
+AKITA_LIST_HTML = """
+<html>
+<body>
+  <a href="/sento/akita-onsen/">秋田温泉</a>
+  <a href="/sento/akita-onsen/">秋田温泉（重複）</a>
+  <a href="https://akita-sento.com/bath/minato/">港の湯</a>
+  <a href="https://akita-sento.com/facility/asahi/">旭湯</a>
+  <a href="/category/news/">お知らせ</a>
+  <a href="https://example.com/sento/outside/">外部</a>
+</body>
+</html>
+"""
+
+
+def test_get_item_urls_extracts_detail_urls_only(parser: AkitaParser) -> None:
+    urls = parser.get_item_urls(AKITA_LIST_HTML, "https://akita-sento.com/")
+    assert urls == [
+        "https://akita-sento.com/sento/akita-onsen/",
+        "https://akita-sento.com/bath/minato/",
+        "https://akita-sento.com/facility/asahi/",
+    ]
+
+
+def test_get_list_urls(parser: AkitaParser) -> None:
+    assert parser.get_list_urls() == [
+        "https://akita-sento.com/",
+        "https://akita-sento.com/sento/",
+    ]
+
+
+def test_parsers_registry_contains_akita() -> None:
+    assert PARSERS["秋田県"] is AkitaParser


### PR DESCRIPTION
## Summary
- `batch/parsers/akita.py` 新規作成（静的HTML・BeautifulSoup対応）
- akita-sento.com の一覧・個別ページをスクレイピング
- Google Mapsリンク/iframeから座標抽出

## Test plan
- [x] `PARSERS["秋田県"]` に AkitaParser が登録されていること
- [x] 正常系: name/address/座標が取得できること
- [x] table形式・@lat,lng形式の座標抽出
- [x] iframeのembedから座標抽出
- [x] 座標なしの場合 lat/lng = None になること
- [x] 必須項目欠損時に None を返すこと（8テスト全パス）

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)