### PR TITLE
feat(EXPAND-yamagata): 山形県OSMインポート対応

### DIFF
--- a/batch/tests/test_osm_geocoder.py
+++ b/batch/tests/test_osm_geocoder.py
@@ -2,6 +2,9 @@
 import pytest
 
 from osm_geocoder import (
+    PARSER_IMPLEMENTED_PREFECTURES,
+    PREFECTURE_NAMES,
+    PREFECTURE_TO_REGION,
     _build_address,
     extract_coords,
     find_best_match,
@@ -151,3 +154,19 @@ def test_build_address_addr_full_takes_precedence_in_caller() -> None:
     tags = {"addr:province": "愛知県", "addr:city": "名古屋市"}
     result = _build_address(tags, "愛知県")
     assert result == "愛知県名古屋市"
+
+
+# ---------------------------------------------------------------------------
+# OSM import target prefectures
+# ---------------------------------------------------------------------------
+
+def test_yamagata_in_prefecture_names() -> None:
+    assert "山形県" in PREFECTURE_NAMES
+
+
+def test_yamagata_region_is_tohoku() -> None:
+    assert PREFECTURE_TO_REGION["山形県"] == "東北"
+
+
+def test_yamagata_not_in_parser_implemented_prefectures() -> None:
+    assert "山形県" not in PARSER_IMPLEMENTED_PREFECTURES

--- a/batch/tests/test_osm_geocoder.py
+++ b/batch/tests/test_osm_geocoder.py
@@ -1,4 +1,6 @@
 """osm_geocoder モジュールのユニットテスト。"""
+from unittest.mock import Mock
+
 import pytest
 
 from osm_geocoder import (
@@ -8,6 +10,7 @@ from osm_geocoder import (
     _build_address,
     extract_coords,
     find_best_match,
+    import_new_prefecture,
     resolve_facility_type,
 )
 
@@ -170,3 +173,32 @@ def test_yamagata_region_is_tohoku() -> None:
 
 def test_yamagata_not_in_parser_implemented_prefectures() -> None:
     assert "山形県" not in PARSER_IMPLEMENTED_PREFECTURES
+
+
+def test_import_new_yamagata_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    elements = [
+        {
+            "type": "node",
+            "id": 1,
+            "lat": 38.2554,
+            "lon": 140.3396,
+            "tags": {
+                "name": "山形湯",
+                "amenity": "public_bath",
+            },
+        }
+    ]
+    monkeypatch.setattr("osm_geocoder.fetch_osm_bath_facilities", lambda _: elements)
+
+    fetchone_result = Mock()
+    fetchone_result.fetchone.return_value = None
+    session = Mock()
+    session.execute.return_value = fetchone_result
+
+    inserted, skipped, total = import_new_prefecture(session, "山形県", dry_run=True)
+
+    assert inserted == 1
+    assert skipped == 0
+    assert total == 1
+    assert session.execute.call_count == 1
+    session.commit.assert_not_called()


### PR DESCRIPTION
## Summary
- 山形県は銭湯組合公式サイトが不十分なためOSMからのみデータ取得
- `osm_geocoder.py` はすでに全都道府県対応済みのため、コード変更不要
- 山形県が正しくOSMインポート対象として設定されていることを検証するテストを追加

## 実行方法
```bash
uv run python osm_geocoder.py --import-new --prefecture 山形県 --dry-run
```

## Test plan
- [x] `PREFECTURE_NAMES` に "山形県" が含まれること
- [x] `PREFECTURE_TO_REGION["山形県"]` が "東北" であること
- [x] `PARSER_IMPLEMENTED_PREFECTURES` に "山形県" が含まれないこと（3テスト全パス）

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)