### PR TITLE
feat(EXPAND-fukushima): 福島県銭湯パーサー実装

### DIFF
--- a/batch/parsers/__init__.py
+++ b/batch/parsers/__init__.py
@@ -10,6 +10,7 @@ from parsers.hyogo import HyogoParser
 from parsers.saitama import SaitamaParser
 from parsers.chiba import ChibaParser
 from parsers.hokkaido import HokkaidoParser
+from parsers.fukushima import FukushimaParser
 
 PARSERS: dict[str, type[BaseParser]] = {
     "東京都": TokyoParser,
@@ -22,10 +23,11 @@ PARSERS: dict[str, type[BaseParser]] = {
     "埼玉県": SaitamaParser,
     "千葉県": ChibaParser,
     "北海道": HokkaidoParser,
+    "福島県": FukushimaParser,
 }
 
 __all__ = [
     "BaseParser", "TokyoParser", "KyotoParser", "FukuokaParser",
     "OsakaParser", "AichiParser", "KanagawaParser", "HyogoParser",
-    "SaitamaParser", "ChibaParser", "HokkaidoParser", "PARSERS",
+    "SaitamaParser", "ChibaParser", "HokkaidoParser", "FukushimaParser", "PARSERS",
 ]

--- a/batch/parsers/fukushima.py
+++ b/batch/parsers/fukushima.py
@@ -2,7 +2,7 @@
 import logging
 import re
 from typing import Optional
-from urllib.parse import urljoin, urlparse
+from urllib.parse import parse_qs, urljoin, urlparse
 
 from bs4 import BeautifulSoup
 
@@ -17,6 +17,9 @@ LIST_URL = f"{BASE_URL}/"
 _GMAPS_Q_PATTERN = re.compile(r"[?&]q=([-\d.]+),([-\d.]+)")
 _DESTINATION_PATTERN = re.compile(r"destination=([-\d.]+),([-\d.]+)")
 _GMAPS_LL_PATTERN = re.compile(r"[?&]ll=([-\d.]+),([-\d.]+)")
+_GMAPS_AT_PATTERN = re.compile(r"/@([-\d.]+),([-\d.]+)")
+_GMAPS_EMBED_PATTERN = re.compile(r"!3d([-\d.]+)!.*!4d([-\d.]+)")
+_GMAPS_EMBED_2D3D_PATTERN = re.compile(r"!2d([-\d.]+)!3d([-\d.]+)")
 
 # 一覧ページから拾う個別ページ URL の候補
 _DETAIL_PATH_PATTERN = re.compile(
@@ -87,8 +90,11 @@ class FukushimaParser(BaseParser):
         address = (
             self.extract_label_value(soup, "住所")
             or self.extract_table_value(soup, "住所")
-            or ""
+            or None
         )
+        if not address:
+            logger.warning("address が取得できません: %s", page_url)
+            return None
         phone = (
             self.extract_label_value(soup, "TEL")
             or self.extract_label_value(soup, "電話")
@@ -117,19 +123,22 @@ class FukushimaParser(BaseParser):
 
         for maps_tag in soup.find_all("a", href=True):
             href: str = maps_tag["href"]
-            if "google.com/maps" not in href:
+            if "google." not in href or "/maps" not in href:
                 continue
-            for pat in (_GMAPS_Q_PATTERN, _DESTINATION_PATTERN, _GMAPS_LL_PATTERN):
-                m = pat.search(href)
-                if m:
-                    try:
-                        lat = float(m.group(1))
-                        lng = float(m.group(2))
-                    except ValueError:
-                        pass
-                    break
-            if lat is not None:
+            coords = self._extract_coordinates_from_url(href)
+            if coords is not None:
+                lat, lng = coords
                 break
+
+        if lat is None:
+            for iframe in soup.find_all("iframe", src=True):
+                src = str(iframe["src"])
+                if "google." not in src or "/maps" not in src:
+                    continue
+                coords = self._extract_coordinates_from_url(src)
+                if coords is not None:
+                    lat, lng = coords
+                    break
 
         return {
             **self.make_sento_dict(
@@ -144,3 +153,39 @@ class FukushimaParser(BaseParser):
             ),
             "facility_type": "sento",
         }
+
+    def _extract_coordinates_from_url(self, url: str) -> Optional[tuple[float, float]]:
+        for pattern in (
+            _GMAPS_Q_PATTERN,
+            _DESTINATION_PATTERN,
+            _GMAPS_LL_PATTERN,
+            _GMAPS_AT_PATTERN,
+            _GMAPS_EMBED_PATTERN,
+            _GMAPS_EMBED_2D3D_PATTERN,
+        ):
+            matched = pattern.search(url)
+            if matched:
+                try:
+                    first = float(matched.group(1))
+                    second = float(matched.group(2))
+                    if pattern is _GMAPS_EMBED_2D3D_PATTERN:
+                        return second, first
+                    return first, second
+                except ValueError:
+                    continue
+
+        parsed = urlparse(url)
+        query = parse_qs(parsed.query)
+        for key in ("q", "ll", "destination"):
+            values = query.get(key, [])
+            if not values:
+                continue
+            parts = values[0].split(",")
+            if len(parts) != 2:
+                continue
+            try:
+                return float(parts[0]), float(parts[1])
+            except ValueError:
+                continue
+
+        return None

--- a/batch/parsers/fukushima.py
+++ b/batch/parsers/fukushima.py
@@ -1,0 +1,146 @@
+"""福島県銭湯組合 (fukushima1010.com) パーサー。"""
+import logging
+import re
+from typing import Optional
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+from parsers.base import BaseParser
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://fukushima1010.com"
+LIST_URL = f"{BASE_URL}/"
+
+# Google Maps リンクから緯度経度を抽出
+_GMAPS_Q_PATTERN = re.compile(r"[?&]q=([-\d.]+),([-\d.]+)")
+_DESTINATION_PATTERN = re.compile(r"destination=([-\d.]+),([-\d.]+)")
+_GMAPS_LL_PATTERN = re.compile(r"[?&]ll=([-\d.]+),([-\d.]+)")
+
+# 一覧ページから拾う個別ページ URL の候補
+_DETAIL_PATH_PATTERN = re.compile(
+    r"/(?:sento|bath|shop|facility|sento_list|store)/[^/?#]+/?$|"
+    r"/\d{4}/\d{2}/\d{2}/[^/?#]+/?$"
+)
+_EXCLUDED_PATH_PATTERN = re.compile(
+    r"/(?:wp-admin|wp-login|category|tag|author|feed|contact|privacy|terms)(?:/|$)"
+)
+
+
+class FukushimaParser(BaseParser):
+    prefecture = "福島県"
+    region = "東北"
+
+    def get_list_urls(self) -> list[str]:
+        return [LIST_URL]
+
+    def get_item_urls(self, html: str, page_url: str) -> list[str]:
+        soup = BeautifulSoup(html, "lxml")
+        urls: list[str] = []
+        seen: set[str] = set()
+
+        for a in soup.find_all("a", href=True):
+            href: str = a["href"]
+            if not href.startswith("http"):
+                href = urljoin(BASE_URL, href)
+
+            parsed = urlparse(href)
+            if "fukushima1010.com" not in parsed.netloc:
+                continue
+            if _EXCLUDED_PATH_PATTERN.search(parsed.path):
+                continue
+            if href.rstrip("/") == BASE_URL:
+                continue
+
+            # 一覧ページのカードリンクや典型的な詳細 URL を対象にする
+            classes = set(a.get("class") or [])
+            looks_like_card = bool(classes & {"card", "shop-card", "entry-card", "item-link"})
+            if not (_DETAIL_PATH_PATTERN.search(parsed.path) or looks_like_card):
+                continue
+
+            normalized = href.split("#", 1)[0]
+            if normalized not in seen:
+                seen.add(normalized)
+                urls.append(normalized)
+
+        return urls
+
+    def parse_sento(self, html: str, page_url: str) -> Optional[dict]:
+        soup = BeautifulSoup(html, "lxml")
+
+        # 銭湯名
+        name: Optional[str] = None
+        for selector in ("h1.entry-title", "h1.sento-name", "h1", "h2"):
+            tag = soup.select_one(selector)
+            if tag:
+                raw = tag.get_text(strip=True)
+                if raw and len(raw) < 80:
+                    name = raw
+                    break
+
+        if not name:
+            logger.warning("name が取得できません: %s", page_url)
+            return None
+
+        # 基本情報
+        address = (
+            self.extract_label_value(soup, "住所")
+            or self.extract_table_value(soup, "住所")
+            or ""
+        )
+        phone = (
+            self.extract_label_value(soup, "TEL")
+            or self.extract_label_value(soup, "電話")
+            or self.extract_table_value(soup, "TEL")
+            or self.extract_table_value(soup, "電話")
+        )
+        if not phone:
+            tel_tag = soup.find("a", href=re.compile(r"^tel:"))
+            if tel_tag:
+                phone = tel_tag["href"].replace("tel:", "").strip()
+
+        open_hours = (
+            self.extract_label_value(soup, "営業時間")
+            or self.extract_table_value(soup, "営業時間")
+        )
+        holiday = (
+            self.extract_label_value(soup, "定休日")
+            or self.extract_label_value(soup, "休日")
+            or self.extract_table_value(soup, "定休日")
+            or self.extract_table_value(soup, "休日")
+        )
+
+        # 緯度経度: Google Maps リンク優先。見つからなければ None のまま返し、後段で OSM 補完対象にする。
+        lat: Optional[float] = None
+        lng: Optional[float] = None
+
+        for maps_tag in soup.find_all("a", href=True):
+            href: str = maps_tag["href"]
+            if "google.com/maps" not in href:
+                continue
+            for pat in (_GMAPS_Q_PATTERN, _DESTINATION_PATTERN, _GMAPS_LL_PATTERN):
+                m = pat.search(href)
+                if m:
+                    try:
+                        lat = float(m.group(1))
+                        lng = float(m.group(2))
+                    except ValueError:
+                        pass
+                    break
+            if lat is not None:
+                break
+
+        return {
+            **self.make_sento_dict(
+                name=name,
+                address=address,
+                lat=lat,
+                lng=lng,
+                phone=phone,
+                open_hours=open_hours,
+                holiday=holiday,
+                source_url=page_url,
+            ),
+            "facility_type": "sento",
+        }

--- a/batch/tests/test_fukushima_parser.py
+++ b/batch/tests/test_fukushima_parser.py
@@ -1,0 +1,164 @@
+"""FukushimaParser のユニットテスト。"""
+import pytest
+
+from parsers import PARSERS
+from parsers.fukushima import FukushimaParser
+
+
+@pytest.fixture
+def parser() -> FukushimaParser:
+    return FukushimaParser()
+
+
+def test_get_list_urls(parser: FukushimaParser) -> None:
+    urls = parser.get_list_urls()
+    assert urls == ["https://fukushima1010.com/"]
+
+
+FUKUSHIMA_LIST_HTML = """
+<html>
+<body>
+  <a class="entry-card" href="https://fukushima1010.com/sento/azuma-yu/">あづま湯</a>
+  <a href="/shop/koriyama-no-yu/">郡山の湯</a>
+  <a href="/sento/azuma-yu/#access">同一リンク（重複）</a>
+  <a href="https://fukushima1010.com/category/news/">お知らせ（除外）</a>
+  <a href="https://example.com/sento/x/">外部サイト（除外）</a>
+</body>
+</html>
+"""
+
+
+def test_get_item_urls_collects_detail_links(parser: FukushimaParser) -> None:
+    urls = parser.get_item_urls(FUKUSHIMA_LIST_HTML, "https://fukushima1010.com/")
+
+    assert "https://fukushima1010.com/sento/azuma-yu/" in urls
+    assert "https://fukushima1010.com/shop/koriyama-no-yu/" in urls
+    assert "https://fukushima1010.com/category/news/" not in urls
+    assert all("example.com" not in u for u in urls)
+    assert urls.count("https://fukushima1010.com/sento/azuma-yu/") == 1
+
+
+FUKUSHIMA_DETAIL_HTML_HAPPY = """
+<html>
+<body>
+  <h1 class="entry-title">吾妻湯</h1>
+  <dl>
+    <dt>住所</dt><dd>福島県福島市本町1-2-3</dd>
+    <dt>TEL</dt><dd>024-111-2222</dd>
+    <dt>営業時間</dt><dd>14:00〜22:30</dd>
+    <dt>定休日</dt><dd>木曜日</dd>
+  </dl>
+  <a href="https://www.google.com/maps?q=37.7608,140.4747">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_happy_path(parser: FukushimaParser) -> None:
+    url = "https://fukushima1010.com/sento/azuma-yu/"
+    result = parser.parse_sento(FUKUSHIMA_DETAIL_HTML_HAPPY, url)
+
+    assert result is not None
+    assert result["name"] == "吾妻湯"
+    assert result["address"] == "福島県福島市本町1-2-3"
+    assert result["phone"] == "024-111-2222"
+    assert result["open_hours"] == "14:00〜22:30"
+    assert result["holiday"] == "木曜日"
+    assert result["lat"] == pytest.approx(37.7608)
+    assert result["lng"] == pytest.approx(140.4747)
+    assert result["prefecture"] == "福島県"
+    assert result["region"] == "東北"
+    assert result["facility_type"] == "sento"
+    assert result["source_url"] == url
+
+
+FUKUSHIMA_DETAIL_HTML_DESTINATION = """
+<html>
+<body>
+  <h1>郡山の湯</h1>
+  <dl>
+    <dt>住所</dt><dd>福島県郡山市駅前2-3-4</dd>
+  </dl>
+  <a href="https://www.google.com/maps?destination=37.4000,140.3900">Google Map</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_destination_coords(parser: FukushimaParser) -> None:
+    result = parser.parse_sento(
+        FUKUSHIMA_DETAIL_HTML_DESTINATION,
+        "https://fukushima1010.com/shop/koriyama-no-yu/",
+    )
+
+    assert result is not None
+    assert result["lat"] == pytest.approx(37.4000)
+    assert result["lng"] == pytest.approx(140.3900)
+
+
+FUKUSHIMA_DETAIL_HTML_TABLE_AND_TEL = """
+<html>
+<body>
+  <h2>会津さくら湯</h2>
+  <table>
+    <tr><th>住所</th><td>福島県会津若松市1-1</td></tr>
+    <tr><th>営業時間</th><td>15:00〜23:00</td></tr>
+    <tr><th>休日</th><td>毎週火曜日</td></tr>
+  </table>
+  <a href="tel:0242-12-3456">電話</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_supports_table_and_tel(parser: FukushimaParser) -> None:
+    result = parser.parse_sento(
+        FUKUSHIMA_DETAIL_HTML_TABLE_AND_TEL,
+        "https://fukushima1010.com/sento/aizu-sakura-yu/",
+    )
+
+    assert result is not None
+    assert result["address"] == "福島県会津若松市1-1"
+    assert result["phone"] == "0242-12-3456"
+    assert result["open_hours"] == "15:00〜23:00"
+    assert result["holiday"] == "毎週火曜日"
+
+
+FUKUSHIMA_DETAIL_HTML_NO_MAPS = """
+<html>
+<body>
+  <h1>いわき湯</h1>
+  <dl>
+    <dt>住所</dt><dd>福島県いわき市平3-4-5</dd>
+  </dl>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_lat_lng_none_when_no_google_maps(parser: FukushimaParser) -> None:
+    result = parser.parse_sento(
+        FUKUSHIMA_DETAIL_HTML_NO_MAPS,
+        "https://fukushima1010.com/sento/iwaki-yu/",
+    )
+
+    assert result is not None
+    assert result["lat"] is None
+    assert result["lng"] is None
+
+
+FUKUSHIMA_DETAIL_HTML_NO_NAME = """
+<html><body><p>施設情報</p></body></html>
+"""
+
+
+def test_parse_sento_returns_none_when_name_missing(parser: FukushimaParser) -> None:
+    result = parser.parse_sento(
+        FUKUSHIMA_DETAIL_HTML_NO_NAME,
+        "https://fukushima1010.com/sento/unknown/",
+    )
+    assert result is None
+
+
+def test_parser_registration_for_fukushima() -> None:
+    assert PARSERS["福島県"] is FukushimaParser

--- a/batch/tests/test_fukushima_parser.py
+++ b/batch/tests/test_fukushima_parser.py
@@ -160,5 +160,62 @@ def test_parse_sento_returns_none_when_name_missing(parser: FukushimaParser) -> 
     assert result is None
 
 
+FUKUSHIMA_DETAIL_HTML_NO_ADDRESS = """
+<html><body><h1>住所なし湯</h1></body></html>
+"""
+
+
+def test_parse_sento_returns_none_when_address_missing(parser: FukushimaParser) -> None:
+    result = parser.parse_sento(
+        FUKUSHIMA_DETAIL_HTML_NO_ADDRESS,
+        "https://fukushima1010.com/sento/no-address-yu/",
+    )
+    assert result is None
+
+
+FUKUSHIMA_DETAIL_HTML_IFRAME = """
+<html>
+<body>
+  <h1>磐梯湯</h1>
+  <dl><dt>住所</dt><dd>福島県郡山市1-2-3</dd></dl>
+  <iframe src="https://www.google.com/maps?q=37.4001,140.3801"></iframe>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_iframe_coords(parser: FukushimaParser) -> None:
+    result = parser.parse_sento(
+        FUKUSHIMA_DETAIL_HTML_IFRAME,
+        "https://fukushima1010.com/sento/bandai-yu/",
+    )
+
+    assert result is not None
+    assert result["lat"] == pytest.approx(37.4001)
+    assert result["lng"] == pytest.approx(140.3801)
+
+
+FUKUSHIMA_DETAIL_HTML_AT_COORDS = """
+<html>
+<body>
+  <h1>会津湯</h1>
+  <dl><dt>住所</dt><dd>福島県会津若松市4-5-6</dd></dl>
+  <a href="https://www.google.com/maps/place/%E4%BC%9A%E6%B4%A5/@37.4947,139.9299,16z">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_at_coords(parser: FukushimaParser) -> None:
+    result = parser.parse_sento(
+        FUKUSHIMA_DETAIL_HTML_AT_COORDS,
+        "https://fukushima1010.com/sento/aizu-yu/",
+    )
+
+    assert result is not None
+    assert result["lat"] == pytest.approx(37.4947)
+    assert result["lng"] == pytest.approx(139.9299)
+
+
 def test_parser_registration_for_fukushima() -> None:
     assert PARSERS["福島県"] is FukushimaParser


### PR DESCRIPTION
## Summary
- `batch/parsers/fukushima.py` 新規作成（fukushima1010.com スクレイピング）
- 一覧ページから個別ページリンクを収集、Google Mapsリンクから座標抽出

## Test plan
- [x] `PARSERS["福島県"]` に FukushimaParser が登録されていること
- [x] 一覧・詳細URL収集・除外・重複除去が正しく動作すること
- [x] 正常系・座標なし・name欠落時の各動作を確認（8テスト全パス）

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)