### PR TITLE
feat(EXPAND-tochigi): 栃木県銭湯パーサー実装

### DIFF
--- a/batch/parsers/__init__.py
+++ b/batch/parsers/__init__.py
@@ -10,6 +10,7 @@ from parsers.hyogo import HyogoParser
 from parsers.saitama import SaitamaParser
 from parsers.chiba import ChibaParser
 from parsers.hokkaido import HokkaidoParser
+from parsers.tochigi import TochigiParser
 
 PARSERS: dict[str, type[BaseParser]] = {
     "東京都": TokyoParser,
@@ -22,10 +23,11 @@ PARSERS: dict[str, type[BaseParser]] = {
     "埼玉県": SaitamaParser,
     "千葉県": ChibaParser,
     "北海道": HokkaidoParser,
+    "栃木県": TochigiParser,
 }
 
 __all__ = [
     "BaseParser", "TokyoParser", "KyotoParser", "FukuokaParser",
     "OsakaParser", "AichiParser", "KanagawaParser", "HyogoParser",
-    "SaitamaParser", "ChibaParser", "HokkaidoParser", "PARSERS",
+    "SaitamaParser", "ChibaParser", "HokkaidoParser", "TochigiParser", "PARSERS",
 ]

--- a/batch/parsers/tochigi.py
+++ b/batch/parsers/tochigi.py
@@ -1,0 +1,188 @@
+"""栃木県銭湯組合 (tochigi1010.jp) パーサー。
+
+実装方針:
+- 一覧ページから個別ページ URL を収集
+- 個別ページから基本情報を抽出
+- 座標は Google Maps リンクから抽出
+- Google Maps リンクが無い場合は lat/lng=None（OSM 補完を想定）
+"""
+import logging
+import re
+from typing import Optional
+from urllib.parse import parse_qs, urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+from parsers.base import BaseParser
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://tochigi1010.jp"
+LIST_URL = f"{BASE_URL}/shoplist/"
+
+_DETAIL_URL_PATTERN = re.compile(
+    r"/(?:shop|sento|tenpo|store|detail)/[^/?#]+/?$|/page/detail/l/\d+/?$"
+)
+_EXCLUDED_PATH_PATTERN = re.compile(
+    r"/(?:shoplist|list|category|tag|news|blog|about|contact|privacy|wp-admin|wp-login|page/\d+)/?",
+    re.IGNORECASE,
+)
+
+_GMAPS_Q_PATTERN = re.compile(r"[?&]q=([-\d.]+),([-\d.]+)")
+_DESTINATION_PATTERN = re.compile(r"[?&]destination=([-\d.]+),([-\d.]+)")
+_LL_PATTERN = re.compile(r"[?&]ll=([-\d.]+),([-\d.]+)")
+_AT_PATTERN = re.compile(r"@([-\d.]+),([-\d.]+),")
+_QUERY_COORD_PATTERN = re.compile(r"^([-\d.]+),([-\d.]+)$")
+_PHONE_PATTERN = re.compile(r"(0\d{1,4}-\d{1,4}-\d{3,4})")
+
+
+class TochigiParser(BaseParser):
+    prefecture = "栃木県"
+    region = "関東"
+
+    def get_list_urls(self) -> list[str]:
+        return [LIST_URL]
+
+    def get_item_urls(self, html: str, page_url: str) -> list[str]:
+        soup = BeautifulSoup(html, "lxml")
+        urls: list[str] = []
+        seen: set[str] = set()
+
+        for a in soup.find_all("a", href=True):
+            href: str = a["href"]
+            if not href.startswith("http"):
+                href = urljoin(BASE_URL, href)
+
+            parsed = urlparse(href)
+            if "tochigi1010.jp" not in parsed.netloc:
+                continue
+            if _EXCLUDED_PATH_PATTERN.search(parsed.path):
+                continue
+            if not _DETAIL_URL_PATTERN.search(parsed.path):
+                continue
+
+            normalized = href.rstrip("/") + "/"
+            if normalized not in seen:
+                seen.add(normalized)
+                urls.append(normalized)
+
+        return urls
+
+    def parse_sento(self, html: str, page_url: str) -> Optional[dict]:
+        soup = BeautifulSoup(html, "lxml")
+
+        name = self._extract_name(soup)
+        if not name:
+            logger.warning("name が取得できません: %s", page_url)
+            return None
+
+        address = (
+            self.extract_label_value(soup, "住所")
+            or self.extract_table_value(soup, "住所")
+            or self._extract_text_by_label(soup, "住所")
+            or ""
+        )
+        phone = (
+            self.extract_label_value(soup, "TEL")
+            or self.extract_label_value(soup, "電話")
+            or self.extract_table_value(soup, "TEL")
+            or self.extract_table_value(soup, "電話")
+            or self._extract_tel_link(soup)
+            or self._extract_text_by_label(soup, "TEL")
+            or self._extract_text_by_label(soup, "電話")
+        )
+        open_hours = (
+            self.extract_label_value(soup, "営業時間")
+            or self.extract_table_value(soup, "営業時間")
+            or self._extract_text_by_label(soup, "営業時間")
+        )
+        holiday = (
+            self.extract_label_value(soup, "定休日")
+            or self.extract_label_value(soup, "休日")
+            or self.extract_table_value(soup, "定休日")
+            or self.extract_table_value(soup, "休業日")
+            or self._extract_text_by_label(soup, "定休日")
+            or self._extract_text_by_label(soup, "休日")
+        )
+
+        lat: Optional[float] = None
+        lng: Optional[float] = None
+        for maps_tag in soup.find_all("a", href=True):
+            href: str = maps_tag["href"]
+            if "google." not in href or "/maps" not in href:
+                continue
+            coords = self._extract_coords_from_map_url(href)
+            if coords:
+                lat, lng = coords
+                break
+
+        return {
+            **self.make_sento_dict(
+                name=name,
+                address=address,
+                lat=lat,
+                lng=lng,
+                phone=phone,
+                open_hours=open_hours,
+                holiday=holiday,
+                source_url=page_url,
+            ),
+            "facility_type": "sento",
+        }
+
+    def _extract_name(self, soup: BeautifulSoup) -> Optional[str]:
+        for selector in ("h1.entry-title", "h1.sento-name", "h1", "h2"):
+            tag = soup.select_one(selector)
+            if not tag:
+                continue
+            raw = tag.get_text(" ", strip=True)
+            if not raw:
+                continue
+            name = raw.split("|")[0].split("｜")[0].strip()
+            if 1 <= len(name) <= 60:
+                return name
+        return None
+
+    @staticmethod
+    def _extract_text_by_label(soup: BeautifulSoup, label: str) -> Optional[str]:
+        text = soup.get_text(separator="\n")
+        m = re.search(rf"{re.escape(label)}\s*[:：]\s*(.+)", text)
+        if m:
+            value = m.group(1).strip()
+            return value if value else None
+        return None
+
+    @staticmethod
+    def _extract_tel_link(soup: BeautifulSoup) -> Optional[str]:
+        tel_tag = soup.find("a", href=re.compile(r"^tel:"))
+        if not tel_tag:
+            return None
+        return tel_tag["href"].replace("tel:", "").strip()
+
+    @staticmethod
+    def _extract_coords_from_map_url(url: str) -> Optional[tuple[float, float]]:
+        for pattern in (_GMAPS_Q_PATTERN, _DESTINATION_PATTERN, _LL_PATTERN, _AT_PATTERN):
+            m = pattern.search(url)
+            if not m:
+                continue
+            try:
+                return float(m.group(1)), float(m.group(2))
+            except ValueError:
+                continue
+
+        parsed = urlparse(url)
+        query = parse_qs(parsed.query)
+        q_values = query.get("query", []) + query.get("q", [])
+        for value in q_values:
+            m = _QUERY_COORD_PATTERN.match(value)
+            if not m:
+                continue
+            try:
+                return float(m.group(1)), float(m.group(2))
+            except ValueError:
+                continue
+
+        m_phone = _PHONE_PATTERN.search(url)
+        if m_phone:
+            return None
+        return None

--- a/batch/tests/test_tochigi_parser.py
+++ b/batch/tests/test_tochigi_parser.py
@@ -1,0 +1,134 @@
+"""TochigiParser のユニットテスト。"""
+import pytest
+
+from parsers import PARSERS
+from parsers.tochigi import TochigiParser
+
+
+@pytest.fixture
+def parser() -> TochigiParser:
+    return TochigiParser()
+
+
+TOCHIGI_LIST_HTML = """
+<html>
+<body>
+  <a href="/shop/utsunomiya-yu/">宇都宮湯</a>
+  <a href="https://tochigi1010.jp/sento/ashikaga-no-yu/">足利の湯</a>
+  <a href="/shoplist/">一覧</a>
+  <a href="/news/notice/">お知らせ</a>
+  <a href="https://example.com/shop/other/">外部</a>
+</body>
+</html>
+"""
+
+
+def test_get_list_urls(parser: TochigiParser) -> None:
+    assert parser.get_list_urls() == ["https://tochigi1010.jp/shoplist/"]
+
+
+def test_get_item_urls_extracts_detail_links(parser: TochigiParser) -> None:
+    urls = parser.get_item_urls(TOCHIGI_LIST_HTML, "https://tochigi1010.jp/shoplist/")
+    assert "https://tochigi1010.jp/shop/utsunomiya-yu/" in urls
+    assert "https://tochigi1010.jp/sento/ashikaga-no-yu/" in urls
+    assert all("example.com" not in u for u in urls)
+    assert all("/shoplist/" not in u for u in urls)
+
+
+def test_get_item_urls_deduplicates(parser: TochigiParser) -> None:
+    html = """
+    <html><body>
+      <a href="/shop/utsunomiya-yu/">A</a>
+      <a href="/shop/utsunomiya-yu/">A duplicate</a>
+    </body></html>
+    """
+    urls = parser.get_item_urls(html, "https://tochigi1010.jp/shoplist/")
+    assert len(urls) == 1
+
+
+TOCHIGI_DETAIL_HTML_HAPPY = """
+<html>
+<body>
+  <h1 class="entry-title">宇都宮湯</h1>
+  <dl>
+    <dt>住所</dt><dd>栃木県宇都宮市1-2-3</dd>
+    <dt>TEL</dt><dd>028-111-2222</dd>
+    <dt>営業時間</dt><dd>15:00〜23:00</dd>
+    <dt>定休日</dt><dd>月曜日</dd>
+  </dl>
+  <a href="https://www.google.com/maps?q=36.5551,139.8828">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_happy_path(parser: TochigiParser) -> None:
+    url = "https://tochigi1010.jp/shop/utsunomiya-yu/"
+    result = parser.parse_sento(TOCHIGI_DETAIL_HTML_HAPPY, url)
+
+    assert result is not None
+    assert result["name"] == "宇都宮湯"
+    assert result["address"] == "栃木県宇都宮市1-2-3"
+    assert result["phone"] == "028-111-2222"
+    assert result["open_hours"] == "15:00〜23:00"
+    assert result["holiday"] == "月曜日"
+    assert result["lat"] == pytest.approx(36.5551)
+    assert result["lng"] == pytest.approx(139.8828)
+    assert result["prefecture"] == "栃木県"
+    assert result["region"] == "関東"
+    assert result["facility_type"] == "sento"
+    assert result["source_url"] == url
+
+
+TOCHIGI_DETAIL_HTML_DESTINATION = """
+<html>
+<body>
+  <h1>足利の湯</h1>
+  <table>
+    <tr><th>住所</th><td>栃木県足利市2-3-4</td></tr>
+    <tr><th>電話</th><td>0284-11-3333</td></tr>
+    <tr><th>営業時間</th><td>14:00〜22:00</td></tr>
+    <tr><th>休業日</th><td>火曜日</td></tr>
+  </table>
+  <a href="https://www.google.com/maps?destination=36.3380,139.4497">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_destination_coords(parser: TochigiParser) -> None:
+    result = parser.parse_sento(TOCHIGI_DETAIL_HTML_DESTINATION, "https://tochigi1010.jp/sento/ashikaga-no-yu/")
+    assert result is not None
+    assert result["lat"] == pytest.approx(36.3380)
+    assert result["lng"] == pytest.approx(139.4497)
+    assert result["holiday"] == "火曜日"
+
+
+TOCHIGI_DETAIL_HTML_TEL_AND_NO_MAP = """
+<html>
+<body>
+  <h1>小山湯</h1>
+  <p>住所: 栃木県小山市5-6-7</p>
+  <a href="tel:0285-55-6666">電話</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_tel_link_and_osm_fallback_none(parser: TochigiParser) -> None:
+    result = parser.parse_sento(TOCHIGI_DETAIL_HTML_TEL_AND_NO_MAP, "https://tochigi1010.jp/shop/oyama-yu/")
+    assert result is not None
+    assert result["phone"] == "0285-55-6666"
+    assert result["lat"] is None
+    assert result["lng"] is None
+
+
+def test_parse_sento_returns_none_when_name_missing(parser: TochigiParser) -> None:
+    html = "<html><body><p>情報なし</p></body></html>"
+    result = parser.parse_sento(html, "https://tochigi1010.jp/shop/unknown/")
+    assert result is None
+
+
+def test_parsers_register_tochigi() -> None:
+    assert "栃木県" in PARSERS
+    assert PARSERS["栃木県"] is TochigiParser


### PR DESCRIPTION
## Summary
- `batch/parsers/tochigi.py` 新規作成（tochigi1010.jp）
- 一覧ページから個別ページリンク収集、Google Mapsリンクから座標抽出

## Test plan
- [x] `PARSERS["栃木県"]` が登録されていること（8テスト全パス）

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)