### PR TITLE
feat(EXPAND-ibaraki): 茨城県銭湯パーサー実装

### DIFF
--- a/batch/parsers/__init__.py
+++ b/batch/parsers/__init__.py
@@ -10,6 +10,7 @@ from parsers.hyogo import HyogoParser
 from parsers.saitama import SaitamaParser
 from parsers.chiba import ChibaParser
 from parsers.hokkaido import HokkaidoParser
+from parsers.ibaraki import IbarakiParser
 
 PARSERS: dict[str, type[BaseParser]] = {
     "東京都": TokyoParser,
@@ -22,10 +23,11 @@ PARSERS: dict[str, type[BaseParser]] = {
     "埼玉県": SaitamaParser,
     "千葉県": ChibaParser,
     "北海道": HokkaidoParser,
+    "茨城県": IbarakiParser,
 }
 
 __all__ = [
     "BaseParser", "TokyoParser", "KyotoParser", "FukuokaParser",
     "OsakaParser", "AichiParser", "KanagawaParser", "HyogoParser",
-    "SaitamaParser", "ChibaParser", "HokkaidoParser", "PARSERS",
+    "SaitamaParser", "ChibaParser", "HokkaidoParser", "IbarakiParser", "PARSERS",
 ]

--- a/batch/parsers/ibaraki.py
+++ b/batch/parsers/ibaraki.py
@@ -1,0 +1,163 @@
+"""茨城県銭湯組合 (ibaraki1010.com) パーサー。"""
+import logging
+import re
+from typing import Optional
+from urllib.parse import unquote, urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+from parsers.base import BaseParser
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://ibaraki1010.com"
+LIST_URL = f"{BASE_URL}/"
+
+_EXCLUDE_PATH_PATTERNS = (
+    r"^/$",
+    r"^/news",
+    r"^/category",
+    r"^/tag",
+    r"^/contact",
+    r"^/about",
+    r"^/privacy",
+    r"^/policy",
+    r"^/terms",
+    r"^/sitemap",
+    r"^/wp-",
+)
+
+_GMAPS_COORD_PATTERNS = (
+    re.compile(r"[?&]q=([-\d.]+),([-\d.]+)"),
+    re.compile(r"[?&]ll=([-\d.]+),([-\d.]+)"),
+    re.compile(r"[?&]query=([-\d.]+),([-\d.]+)"),
+    re.compile(r"[?&]destination=([-\d.]+),([-\d.]+)"),
+    re.compile(r"/@([-\d.]+),([-\d.]+)"),
+)
+_ADDRESS_FALLBACK_PATTERN = re.compile(r"(?:住所|所在地)\s*[:：]\s*([^\n]+)")
+
+
+class IbarakiParser(BaseParser):
+    prefecture = "茨城県"
+    region = "関東"
+
+    def get_list_urls(self) -> list[str]:
+        return [LIST_URL]
+
+    def get_item_urls(self, html: str, page_url: str) -> list[str]:
+        soup = BeautifulSoup(html, "lxml")
+        urls: list[str] = []
+        seen: set[str] = set()
+
+        for a in soup.find_all("a", href=True):
+            href: str = a["href"].strip()
+            if href.startswith(("mailto:", "tel:", "javascript:", "#")):
+                continue
+
+            abs_url = urljoin(BASE_URL, href)
+            parsed = urlparse(abs_url)
+            if parsed.scheme not in ("http", "https"):
+                continue
+            if "ibaraki1010.com" not in parsed.netloc:
+                continue
+            if any(re.search(pattern, parsed.path) for pattern in _EXCLUDE_PATH_PATTERNS):
+                continue
+
+            normalized = parsed._replace(fragment="").geturl()
+            if normalized in seen:
+                continue
+
+            seen.add(normalized)
+            urls.append(normalized)
+
+        return urls
+
+    def parse_sento(self, html: str, page_url: str) -> Optional[dict]:
+        soup = BeautifulSoup(html, "lxml")
+
+        name: Optional[str] = None
+        for selector in ("h1", "h2.entry-title", "h2", ".entry-title", ".post-title"):
+            tag = soup.select_one(selector)
+            if not tag:
+                continue
+            raw = tag.get_text(" ", strip=True)
+            if raw and len(raw) < 80:
+                name = re.sub(r"\s*[|｜\-].*$", "", raw).strip()
+                break
+
+        if not name:
+            logger.warning("name が取得できません: %s", page_url)
+            return None
+
+        address = (
+            self.extract_label_value(soup, "住所")
+            or self.extract_label_value(soup, "所在地")
+            or self.extract_table_value(soup, "住所")
+            or self.extract_table_value(soup, "所在地")
+            or self._extract_address_fallback(soup)
+            or ""
+        )
+        phone = (
+            self.extract_label_value(soup, "TEL")
+            or self.extract_label_value(soup, "電話")
+            or self.extract_table_value(soup, "TEL")
+            or self.extract_table_value(soup, "電話")
+        )
+        if not phone:
+            tel_tag = soup.find("a", href=re.compile(r"^tel:"))
+            if tel_tag:
+                phone = tel_tag["href"].replace("tel:", "").strip()
+
+        open_hours = (
+            self.extract_label_value(soup, "営業時間")
+            or self.extract_label_value(soup, "入浴時間")
+            or self.extract_table_value(soup, "営業時間")
+            or self.extract_table_value(soup, "入浴時間")
+        )
+        holiday = (
+            self.extract_label_value(soup, "定休日")
+            or self.extract_label_value(soup, "休日")
+            or self.extract_table_value(soup, "定休日")
+            or self.extract_table_value(soup, "休業日")
+            or self.extract_table_value(soup, "休日")
+        )
+
+        lat, lng = self._extract_coords_from_maps_link(soup)
+
+        return {
+            **self.make_sento_dict(
+                name=name,
+                address=address,
+                lat=lat,
+                lng=lng,
+                phone=phone,
+                open_hours=open_hours,
+                holiday=holiday,
+                source_url=page_url,
+            ),
+            "facility_type": "sento",
+        }
+
+    @staticmethod
+    def _extract_address_fallback(soup: BeautifulSoup) -> Optional[str]:
+        text = soup.get_text("\n", strip=True)
+        m = _ADDRESS_FALLBACK_PATTERN.search(text)
+        if not m:
+            return None
+        return m.group(1).strip()
+
+    @staticmethod
+    def _extract_coords_from_maps_link(soup: BeautifulSoup) -> tuple[Optional[float], Optional[float]]:
+        for a in soup.find_all("a", href=True):
+            href = unquote(a["href"])
+            if "google.com/maps" not in href and "maps.app.goo.gl" not in href:
+                continue
+            for pattern in _GMAPS_COORD_PATTERNS:
+                m = pattern.search(href)
+                if not m:
+                    continue
+                try:
+                    return float(m.group(1)), float(m.group(2))
+                except ValueError:
+                    continue
+        return None, None

--- a/batch/tests/test_ibaraki_parser.py
+++ b/batch/tests/test_ibaraki_parser.py
@@ -1,0 +1,151 @@
+"""IbarakiParser のユニットテスト。"""
+import pytest
+
+from parsers.ibaraki import IbarakiParser
+
+
+@pytest.fixture
+def parser() -> IbarakiParser:
+    return IbarakiParser()
+
+
+IBARAKI_DETAIL_HTML_HAPPY = """
+<html>
+<body>
+  <h1>みと湯</h1>
+  <dl>
+    <dt>住所</dt><dd>茨城県水戸市中央1-2-3</dd>
+    <dt>TEL</dt><dd>029-123-4567</dd>
+    <dt>営業時間</dt><dd>15:00〜23:00</dd>
+    <dt>定休日</dt><dd>月曜日</dd>
+  </dl>
+  <a href="https://www.google.com/maps?q=36.3658,140.4712">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_happy_path(parser: IbarakiParser) -> None:
+    result = parser.parse_sento(IBARAKI_DETAIL_HTML_HAPPY, "https://ibaraki1010.com/sento/mitoyu/")
+
+    assert result is not None
+    assert result["name"] == "みと湯"
+    assert result["address"] == "茨城県水戸市中央1-2-3"
+    assert result["phone"] == "029-123-4567"
+    assert result["open_hours"] == "15:00〜23:00"
+    assert result["holiday"] == "月曜日"
+    assert result["lat"] == pytest.approx(36.3658)
+    assert result["lng"] == pytest.approx(140.4712)
+    assert result["prefecture"] == "茨城県"
+    assert result["region"] == "関東"
+    assert result["facility_type"] == "sento"
+
+
+IBARAKI_DETAIL_HTML_MAPS_AT = """
+<html>
+<body>
+  <h1>つくば湯</h1>
+  <p>住所：茨城県つくば市研究学園1-1-1</p>
+  <a href="https://www.google.com/maps/place/%E3%81%A4%E3%81%8F%E3%81%B0%E6%B9%AF/@36.0839,140.0765,17z">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_coords_from_maps_at_path(parser: IbarakiParser) -> None:
+    result = parser.parse_sento(IBARAKI_DETAIL_HTML_MAPS_AT, "https://ibaraki1010.com/sento/tsukuba/")
+    assert result is not None
+    assert result["address"] == "茨城県つくば市研究学園1-1-1"
+    assert result["lat"] == pytest.approx(36.0839)
+    assert result["lng"] == pytest.approx(140.0765)
+
+
+IBARAKI_DETAIL_HTML_NO_COORDS = """
+<html>
+<body>
+  <h1>ひたち湯</h1>
+  <dl>
+    <dt>住所</dt><dd>茨城県日立市幸町2-2-2</dd>
+  </dl>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_without_maps_link_returns_none_coords(parser: IbarakiParser) -> None:
+    result = parser.parse_sento(IBARAKI_DETAIL_HTML_NO_COORDS, "https://ibaraki1010.com/sento/hitachi/")
+    assert result is not None
+    assert result["lat"] is None
+    assert result["lng"] is None
+
+
+IBARAKI_DETAIL_HTML_TEL_LINK_TABLE = """
+<html>
+<body>
+  <h1>土浦湯</h1>
+  <table>
+    <tr><th>所在地</th><td>茨城県土浦市桜町3-3-3</td></tr>
+    <tr><th>入浴時間</th><td>16:00〜22:30</td></tr>
+    <tr><th>休業日</th><td>木曜日</td></tr>
+  </table>
+  <a href="tel:029-222-3333">電話する</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_table_and_tel_link(parser: IbarakiParser) -> None:
+    result = parser.parse_sento(IBARAKI_DETAIL_HTML_TEL_LINK_TABLE, "https://ibaraki1010.com/sento/tsuchiura/")
+    assert result is not None
+    assert result["address"] == "茨城県土浦市桜町3-3-3"
+    assert result["phone"] == "029-222-3333"
+    assert result["open_hours"] == "16:00〜22:30"
+    assert result["holiday"] == "木曜日"
+
+
+IBARAKI_DETAIL_HTML_NO_NAME = """
+<html>
+<body>
+  <p>店舗情報</p>
+  <p>住所：茨城県水戸市</p>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_returns_none_when_name_missing(parser: IbarakiParser) -> None:
+    result = parser.parse_sento(IBARAKI_DETAIL_HTML_NO_NAME, "https://ibaraki1010.com/sento/unknown/")
+    assert result is None
+
+
+IBARAKI_LIST_HTML = """
+<html>
+<body>
+  <a href="/shop/mitoyu/">みと湯</a>
+  <a href="https://ibaraki1010.com/sento/tsukuba/">つくば湯</a>
+  <a href="/news/2026/">ニュース（除外）</a>
+  <a href="/contact/">お問い合わせ（除外）</a>
+  <a href="https://example.com/sento/ext/">外部（除外）</a>
+  <a href="mailto:test@example.com">メール（除外）</a>
+  <a href="/shop/mitoyu/">重複</a>
+</body>
+</html>
+"""
+
+
+def test_get_item_urls_extracts_internal_detail_urls_only(parser: IbarakiParser) -> None:
+    urls = parser.get_item_urls(IBARAKI_LIST_HTML, "https://ibaraki1010.com/")
+    assert "https://ibaraki1010.com/shop/mitoyu/" in urls
+    assert "https://ibaraki1010.com/sento/tsukuba/" in urls
+    assert all("/news/" not in url for url in urls)
+    assert all("/contact/" not in url for url in urls)
+    assert all("example.com" not in url for url in urls)
+
+
+def test_get_item_urls_deduplicates(parser: IbarakiParser) -> None:
+    urls = parser.get_item_urls(IBARAKI_LIST_HTML, "https://ibaraki1010.com/")
+    assert urls.count("https://ibaraki1010.com/shop/mitoyu/") == 1
+
+
+def test_get_list_urls(parser: IbarakiParser) -> None:
+    assert parser.get_list_urls() == ["https://ibaraki1010.com/"]


### PR DESCRIPTION
## Summary
- `batch/parsers/ibaraki.py` 新規作成（ibaraki1010.com 静的HTML・BeautifulSoup）

## Test plan
- [x] `PARSERS["茨城県"]` が登録されていること（8テスト全パス）

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)