### PR TITLE
feat(EXPAND-gunma): 群馬県銭湯パーサー実装

### DIFF
--- a/batch/parsers/__init__.py
+++ b/batch/parsers/__init__.py
@@ -10,6 +10,7 @@ from parsers.hyogo import HyogoParser
 from parsers.saitama import SaitamaParser
 from parsers.chiba import ChibaParser
 from parsers.hokkaido import HokkaidoParser
+from parsers.gunma import GunmaParser
 
 PARSERS: dict[str, type[BaseParser]] = {
     "東京都": TokyoParser,
@@ -22,10 +23,11 @@ PARSERS: dict[str, type[BaseParser]] = {
     "埼玉県": SaitamaParser,
     "千葉県": ChibaParser,
     "北海道": HokkaidoParser,
+    "群馬県": GunmaParser,
 }
 
 __all__ = [
     "BaseParser", "TokyoParser", "KyotoParser", "FukuokaParser",
     "OsakaParser", "AichiParser", "KanagawaParser", "HyogoParser",
-    "SaitamaParser", "ChibaParser", "HokkaidoParser", "PARSERS",
+    "SaitamaParser", "ChibaParser", "HokkaidoParser", "GunmaParser", "PARSERS",
 ]

--- a/batch/parsers/gunma.py
+++ b/batch/parsers/gunma.py
@@ -1,0 +1,236 @@
+"""群馬県公衆浴場業生活衛生同業組合 (gunma1010.com) パーサー。"""
+import logging
+import re
+from typing import Optional
+from urllib.parse import parse_qs, urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+from parsers.base import BaseParser
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://gunma1010.com"
+TOP_URL = f"{BASE_URL}/"
+
+# WordPress 投稿 URL: /YYYY/MM/DD/slug/
+_POST_URL_PATTERN = re.compile(r"/\d{4}/\d{2}/\d{2}/[^/]+/?$")
+# Google Maps リンクの座標パターン
+_GMAPS_Q_PATTERN = re.compile(r"[?&]q=([-\d.]+),([-\d.]+)")
+_GMAPS_LL_PATTERN = re.compile(r"[?&]ll=([-\d.]+),([-\d.]+)")
+_GMAPS_DEST_PATTERN = re.compile(r"[?&]destination=([-\d.]+),([-\d.]+)")
+_GMAPS_DADDR_PATTERN = re.compile(r"[?&]daddr=([-\d.]+),([-\d.]+)")
+_GMAPS_AT_PATTERN = re.compile(r"/@([-\d.]+),([-\d.]+)")
+
+# 一覧ページで使われやすいキーワード
+_LIST_TEXT_KEYWORDS = ("一覧", "エリア", "地区", "地域", "市", "郡")
+_LIST_PATH_KEYWORDS = ("/category/", "/tag/", "/area/", "/list/", "/archive/")
+# 個別ページ名らしいアンカーテキスト
+_DETAIL_TEXT_HINTS = ("湯", "温泉", "浴場", "銭湯")
+# 個別ページではない固定ページのキーワード
+_NON_DETAIL_PATH_KEYWORDS = (
+    "/category/",
+    "/tag/",
+    "/author/",
+    "/page/",
+    "/archive/",
+    "/about",
+    "/contact",
+    "/privacy",
+    "/policy",
+    "/news",
+)
+
+
+class GunmaParser(BaseParser):
+    prefecture = "群馬県"
+    region = "関東"
+
+    def get_list_urls(self) -> list[str]:
+        return [TOP_URL]
+
+    def get_all_list_urls(self, page1_html: str) -> list[str]:
+        """トップページから一覧ページ URL を収集する。"""
+        soup = BeautifulSoup(page1_html, "lxml")
+        urls: list[str] = [TOP_URL]
+        seen: set[str] = {TOP_URL}
+
+        for a in soup.find_all("a", href=True):
+            href = self._normalize_internal_url(a["href"])
+            if not href or href in seen:
+                continue
+
+            text = a.get_text(" ", strip=True)
+            parsed = urlparse(href)
+            query = parse_qs(parsed.query)
+            path = parsed.path.lower()
+
+            is_list = (
+                any(k in text for k in _LIST_TEXT_KEYWORDS)
+                or any(k in path for k in _LIST_PATH_KEYWORDS)
+                or "cat" in query
+                or "paged" in query
+            )
+
+            if is_list and not _POST_URL_PATTERN.search(parsed.path):
+                seen.add(href)
+                urls.append(href)
+
+        return urls
+
+    def get_item_urls(self, html: str, page_url: str) -> list[str]:
+        """一覧ページ HTML から個別銭湯ページ URL を収集する。"""
+        soup = BeautifulSoup(html, "lxml")
+        urls: list[str] = []
+        seen: set[str] = set()
+
+        for a in soup.find_all("a", href=True):
+            raw_href = a["href"]
+            href = self._normalize_internal_url(raw_href)
+            if not href:
+                continue
+
+            if href in seen:
+                continue
+
+            parsed = urlparse(href)
+            path = parsed.path.lower()
+            query = parse_qs(parsed.query)
+            text = a.get_text(" ", strip=True)
+
+            # 日付投稿 URL は個別ページとして採用
+            if _POST_URL_PATTERN.search(parsed.path):
+                seen.add(href)
+                urls.append(href)
+                continue
+
+            # ?p=N は投稿 ID 指定なので個別ページとして採用
+            if "p" in query:
+                seen.add(href)
+                urls.append(href)
+                continue
+
+            # 一覧・管理系は除外
+            if any(k in path for k in _NON_DETAIL_PATH_KEYWORDS):
+                continue
+            if any(k in raw_href for k in ("/wp-admin", "/wp-login", "/feed", "/comments")):
+                continue
+            if "cat" in query or "paged" in query:
+                continue
+
+            # 1階層以上の固定ページで、銭湯名らしいテキストがあるリンクを個別候補にする
+            is_flat_page = path not in ("", "/") and path.count("/") >= 2
+            if is_flat_page and any(h in text for h in _DETAIL_TEXT_HINTS):
+                seen.add(href)
+                urls.append(href)
+
+        return urls
+
+    def parse_sento(self, html: str, page_url: str) -> Optional[dict]:
+        soup = BeautifulSoup(html, "lxml")
+
+        parsed_url = urlparse(page_url)
+        page_query = parse_qs(parsed_url.query)
+        if ("page_id" in page_query or "cat" in page_query) and not self._looks_like_sento_page(soup):
+            return None
+
+        name: Optional[str] = None
+        for selector in (
+            "h1.entry-title",
+            "h1.wp-block-post-title",
+            "h2.entry-title",
+            ".entry-title",
+            "h1",
+            "h2",
+        ):
+            tag = soup.select_one(selector)
+            if not tag:
+                continue
+            raw = tag.get_text(strip=True)
+            if raw and len(raw) < 80:
+                name = raw
+                break
+
+        if not name:
+            logger.warning("name が取得できません: %s", page_url)
+            return None
+
+        address = self.extract_label_value(soup, "住所") or self.extract_table_value(soup, "住所") or ""
+        phone = (
+            self.extract_label_value(soup, "TEL")
+            or self.extract_label_value(soup, "電話")
+            or self.extract_table_value(soup, "TEL")
+            or self.extract_table_value(soup, "電話")
+        )
+        if not phone:
+            tel_tag = soup.find("a", href=re.compile(r"^tel:"))
+            if tel_tag:
+                phone = tel_tag["href"].replace("tel:", "").strip()
+
+        open_hours = self.extract_label_value(soup, "営業時間") or self.extract_table_value(soup, "営業時間")
+        holiday = (
+            self.extract_label_value(soup, "定休日")
+            or self.extract_label_value(soup, "休日")
+            or self.extract_table_value(soup, "定休日")
+            or self.extract_table_value(soup, "休業日")
+            or self.extract_table_value(soup, "休日")
+        )
+
+        lat: Optional[float] = None
+        lng: Optional[float] = None
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            if "google.com/maps" not in href:
+                continue
+            for pattern in (
+                _GMAPS_Q_PATTERN,
+                _GMAPS_LL_PATTERN,
+                _GMAPS_DEST_PATTERN,
+                _GMAPS_DADDR_PATTERN,
+                _GMAPS_AT_PATTERN,
+            ):
+                m = pattern.search(href)
+                if not m:
+                    continue
+                try:
+                    lat = float(m.group(1))
+                    lng = float(m.group(2))
+                except ValueError:
+                    lat = None
+                    lng = None
+                break
+            if lat is not None:
+                break
+
+        return {
+            **self.make_sento_dict(
+                name=name,
+                address=address,
+                lat=lat,
+                lng=lng,
+                phone=phone,
+                open_hours=open_hours,
+                holiday=holiday,
+                source_url=page_url,
+            ),
+            "facility_type": "sento",
+        }
+
+    @staticmethod
+    def _normalize_internal_url(href: str) -> Optional[str]:
+        if not href:
+            return None
+        if href.startswith(("mailto:", "tel:", "javascript:")):
+            return None
+
+        abs_url = href if href.startswith("http") else urljoin(BASE_URL, href)
+        parsed = urlparse(abs_url)
+        if "gunma1010.com" not in parsed.netloc:
+            return None
+        return abs_url
+
+    @staticmethod
+    def _looks_like_sento_page(soup: BeautifulSoup) -> bool:
+        text = soup.get_text(separator="\n")
+        indicators = ("住所", "営業時間", "定休日", "TEL", "電話")
+        return sum(1 for ind in indicators if ind in text) >= 2

--- a/batch/tests/test_gunma_parser.py
+++ b/batch/tests/test_gunma_parser.py
@@ -1,0 +1,160 @@
+"""GunmaParser のユニットテスト。"""
+import pytest
+
+from parsers.gunma import GunmaParser
+
+
+@pytest.fixture
+def parser() -> GunmaParser:
+    return GunmaParser()
+
+
+GUNMA_DETAIL_HTML_HAPPY = """
+<html>
+<body>
+  <h1 class="entry-title">前橋湯</h1>
+  <dl>
+    <dt>住所</dt><dd>群馬県前橋市本町1-2-3</dd>
+    <dt>TEL</dt><dd>027-123-4567</dd>
+    <dt>営業時間</dt><dd>15:00〜23:00</dd>
+    <dt>定休日</dt><dd>月曜日</dd>
+  </dl>
+  <a href="https://www.google.com/maps?q=36.3911,139.0608">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_happy_path(parser: GunmaParser) -> None:
+    result = parser.parse_sento(GUNMA_DETAIL_HTML_HAPPY, "https://gunma1010.com/2025/01/01/maebashi-yu/")
+
+    assert result is not None
+    assert result["name"] == "前橋湯"
+    assert result["address"] == "群馬県前橋市本町1-2-3"
+    assert result["phone"] == "027-123-4567"
+    assert result["open_hours"] == "15:00〜23:00"
+    assert result["holiday"] == "月曜日"
+    assert result["lat"] == pytest.approx(36.3911)
+    assert result["lng"] == pytest.approx(139.0608)
+    assert result["prefecture"] == "群馬県"
+    assert result["region"] == "関東"
+    assert result["facility_type"] == "sento"
+
+
+GUNMA_DETAIL_HTML_MAPS_AT = """
+<html>
+<body>
+  <h1>高崎湯</h1>
+  <dl><dt>住所</dt><dd>群馬県高崎市2-3-4</dd></dl>
+  <a href="https://www.google.com/maps/place/abc/@36.3219,139.0033,17z">Google Map</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_coords_from_maps_at_format(parser: GunmaParser) -> None:
+    result = parser.parse_sento(GUNMA_DETAIL_HTML_MAPS_AT, "https://gunma1010.com/takasaki-yu/")
+    assert result is not None
+    assert result["lat"] == pytest.approx(36.3219)
+    assert result["lng"] == pytest.approx(139.0033)
+
+
+GUNMA_DETAIL_HTML_TABLE_TEL = """
+<html>
+<body>
+  <h1>伊勢崎湯</h1>
+  <table>
+    <tr><td>住所</td><td>群馬県伊勢崎市3-4-5</td></tr>
+    <tr><td>営業時間</td><td>14:00〜22:00</td></tr>
+    <tr><td>休業日</td><td>木曜日</td></tr>
+  </table>
+  <a href="tel:0270-11-2233">電話</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_table_and_tel_link(parser: GunmaParser) -> None:
+    result = parser.parse_sento(GUNMA_DETAIL_HTML_TABLE_TEL, "https://gunma1010.com/isesaki-yu/")
+    assert result is not None
+    assert result["address"] == "群馬県伊勢崎市3-4-5"
+    assert result["open_hours"] == "14:00〜22:00"
+    assert result["holiday"] == "木曜日"
+    assert result["phone"] == "0270-11-2233"
+
+
+GUNMA_DETAIL_HTML_NO_COORDS = """
+<html>
+<body>
+  <h1>桐生湯</h1>
+  <dl><dt>住所</dt><dd>群馬県桐生市4-5-6</dd></dl>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_without_google_maps_link_returns_none_coords(parser: GunmaParser) -> None:
+    result = parser.parse_sento(GUNMA_DETAIL_HTML_NO_COORDS, "https://gunma1010.com/kiryu-yu/")
+    assert result is not None
+    assert result["lat"] is None
+    assert result["lng"] is None
+
+
+def test_parse_sento_returns_none_when_name_missing(parser: GunmaParser) -> None:
+    html = "<html><body><p>銭湯情報</p></body></html>"
+    result = parser.parse_sento(html, "https://gunma1010.com/unknown/")
+    assert result is None
+
+
+def test_parse_sento_returns_none_for_area_page(parser: GunmaParser) -> None:
+    html = """
+    <html><body>
+      <h1>前橋エリア一覧</h1>
+      <a href="https://gunma1010.com/2025/01/01/a/">A</a>
+    </body></html>
+    """
+    result = parser.parse_sento(html, "https://gunma1010.com/?page_id=12")
+    assert result is None
+
+
+def test_get_all_list_urls_collects_top_and_area_links(parser: GunmaParser) -> None:
+    html = """
+    <html><body>
+      <a href="/category/maebashi/">前橋エリア一覧</a>
+      <a href="https://gunma1010.com/list/takasaki/">高崎地区一覧</a>
+      <a href="https://gunma1010.com/?cat=3">桐生地域</a>
+      <a href="https://gunma1010.com/category/maebashi/">前橋エリア一覧（重複）</a>
+      <a href="https://example.com/category/outside/">外部</a>
+    </body></html>
+    """
+    urls = parser.get_all_list_urls(html)
+
+    assert "https://gunma1010.com/" in urls
+    assert "https://gunma1010.com/category/maebashi/" in urls
+    assert "https://gunma1010.com/list/takasaki/" in urls
+    assert "https://gunma1010.com/?cat=3" in urls
+    assert urls.count("https://gunma1010.com/category/maebashi/") == 1
+
+
+def test_get_item_urls_extracts_detail_links_only(parser: GunmaParser) -> None:
+    html = """
+    <html><body>
+      <a href="https://gunma1010.com/2025/01/01/maebashi-yu/">前橋湯</a>
+      <a href="/takasaki-yu/">高崎湯</a>
+      <a href="/?p=42">桐生湯</a>
+      <a href="/category/maebashi/">カテゴリ</a>
+      <a href="/page/2/">ページネーション</a>
+      <a href="https://gunma1010.com/news/">お知らせ</a>
+      <a href="https://example.com/2025/01/01/outside/">外部</a>
+      <a href="/takasaki-yu/">高崎湯（重複）</a>
+    </body></html>
+    """
+    urls = parser.get_item_urls(html, "https://gunma1010.com/category/maebashi/")
+
+    assert "https://gunma1010.com/2025/01/01/maebashi-yu/" in urls
+    assert "https://gunma1010.com/takasaki-yu/" in urls
+    assert "https://gunma1010.com/?p=42" in urls
+    assert "https://gunma1010.com/category/maebashi/" not in urls
+    assert "https://gunma1010.com/news/" not in urls
+    assert all("example.com" not in u for u in urls)
+    assert urls.count("https://gunma1010.com/takasaki-yu/") == 1


### PR DESCRIPTION
## Summary
- `batch/parsers/gunma.py` 新規作成（gunma1010.com WordPress対応）

## Test plan
- [x] `PARSERS["群馬県"]` が登録されていること（8テスト全パス）

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)