### PR TITLE
feat(EXPAND-yamanashi): 山梨県銭湯パーサー実装

### DIFF
--- a/batch/parsers/__init__.py
+++ b/batch/parsers/__init__.py
@@ -10,6 +10,7 @@ from parsers.hyogo import HyogoParser
 from parsers.saitama import SaitamaParser
 from parsers.chiba import ChibaParser
 from parsers.hokkaido import HokkaidoParser
+from parsers.yamanashi import YamanashiParser
 
 PARSERS: dict[str, type[BaseParser]] = {
     "東京都": TokyoParser,
@@ -22,10 +23,11 @@ PARSERS: dict[str, type[BaseParser]] = {
     "埼玉県": SaitamaParser,
     "千葉県": ChibaParser,
     "北海道": HokkaidoParser,
+    "山梨県": YamanashiParser,
 }
 
 __all__ = [
     "BaseParser", "TokyoParser", "KyotoParser", "FukuokaParser",
     "OsakaParser", "AichiParser", "KanagawaParser", "HyogoParser",
-    "SaitamaParser", "ChibaParser", "HokkaidoParser", "PARSERS",
+    "SaitamaParser", "ChibaParser", "HokkaidoParser", "YamanashiParser", "PARSERS",
 ]

--- a/batch/parsers/yamanashi.py
+++ b/batch/parsers/yamanashi.py
@@ -1,0 +1,159 @@
+"""山梨県公衆浴場業生活衛生同業組合 (sento-yamanashi.com) パーサー。"""
+import logging
+import re
+from typing import Optional
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+from parsers.base import BaseParser
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://sento-yamanashi.com"
+LIST_URL = f"{BASE_URL}/"
+
+_PAGINATION_PATTERNS = (
+    re.compile(r"/page/(\d+)/?$"),
+    re.compile(r"[?&]paged=(\d+)(?:[&#].*)?$"),
+    re.compile(r"[?&]page=(\d+)(?:[&#].*)?$"),
+)
+_DETAIL_URL_PATTERNS = (
+    re.compile(r"/(sento|bath|shop)/[^/]+/?$"),
+    re.compile(r"/\d{4}/\d{2}/[^/]+/?$"),
+    re.compile(r"/[^/]+/?$"),
+)
+_GMAPS_PATTERNS = (
+    re.compile(r"[?&]q=([-\d.]+),([-\d.]+)"),
+    re.compile(r"[?&]ll=([-\d.]+),([-\d.]+)"),
+    re.compile(r"destination=([-\d.]+),([-\d.]+)"),
+    re.compile(r"daddr=([-\d.]+),([-\d.]+)"),
+    re.compile(r"/@([-\d.]+),([-\d.]+),"),
+)
+
+
+class YamanashiParser(BaseParser):
+    prefecture = "山梨県"
+    region = "中部"
+
+    def get_list_urls(self) -> list[str]:
+        return [LIST_URL]
+
+    def get_all_list_urls(self, page1_html: str) -> list[str]:
+        """ページ1からページネーション URL を収集する。"""
+        soup = BeautifulSoup(page1_html, "lxml")
+        urls = [LIST_URL]
+        seen = {LIST_URL}
+
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            if not href.startswith("http"):
+                href = urljoin(BASE_URL, href)
+            if "sento-yamanashi.com" not in urlparse(href).netloc:
+                continue
+            if self._is_pagination_url(href) and href not in seen:
+                seen.add(href)
+                urls.append(href)
+
+        return urls
+
+    def get_item_urls(self, html: str, page_url: str) -> list[str]:
+        soup = BeautifulSoup(html, "lxml")
+        urls: list[str] = []
+        seen: set[str] = set()
+
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            if not href.startswith("http"):
+                href = urljoin(BASE_URL, href)
+
+            parsed = urlparse(href)
+            if "sento-yamanashi.com" not in parsed.netloc:
+                continue
+            if self._is_pagination_url(href):
+                continue
+            if any(token in parsed.path for token in ("/category/", "/tag/", "/author/", "/wp-", "/contact", "/about")):
+                continue
+            if parsed.path.rstrip("/") in ("", "/"):
+                continue
+            if not any(pattern.search(parsed.path) for pattern in _DETAIL_URL_PATTERNS):
+                continue
+            if href not in seen:
+                seen.add(href)
+                urls.append(href)
+
+        return urls
+
+    def parse_sento(self, html: str, page_url: str) -> Optional[dict]:
+        soup = BeautifulSoup(html, "lxml")
+
+        name: Optional[str] = None
+        for selector in ("h1.entry-title", "h1.post-title", ".entry-title", ".post-title", "h1", "h2"):
+            tag = soup.select_one(selector)
+            if tag:
+                raw = tag.get_text(strip=True)
+                if raw and len(raw) < 80:
+                    name = raw
+                    break
+
+        if not name:
+            logger.warning("name が取得できません: %s", page_url)
+            return None
+
+        address = self.extract_label_value(soup, "住所") or self.extract_table_value(soup, "住所") or ""
+        phone = (
+            self.extract_label_value(soup, "TEL")
+            or self.extract_label_value(soup, "電話")
+            or self.extract_table_value(soup, "TEL")
+            or self.extract_table_value(soup, "電話")
+        )
+        if not phone:
+            tel_tag = soup.find("a", href=re.compile(r"^tel:"))
+            if tel_tag:
+                phone = tel_tag["href"].replace("tel:", "").strip()
+
+        open_hours = self.extract_label_value(soup, "営業時間") or self.extract_table_value(soup, "営業時間")
+        holiday = (
+            self.extract_label_value(soup, "定休日")
+            or self.extract_label_value(soup, "休日")
+            or self.extract_table_value(soup, "定休日")
+            or self.extract_table_value(soup, "休業日")
+        )
+
+        lat: Optional[float] = None
+        lng: Optional[float] = None
+        for maps_tag in soup.find_all("a", href=True):
+            href = maps_tag["href"]
+            if "google.com/maps" not in href and "maps.google.com" not in href:
+                continue
+            for pattern in _GMAPS_PATTERNS:
+                match = pattern.search(href)
+                if not match:
+                    continue
+                try:
+                    lat = float(match.group(1))
+                    lng = float(match.group(2))
+                except ValueError:
+                    lat = None
+                    lng = None
+                break
+            if lat is not None:
+                break
+
+        return {
+            **self.make_sento_dict(
+                name=name,
+                address=address,
+                lat=lat,
+                lng=lng,
+                phone=phone,
+                open_hours=open_hours,
+                holiday=holiday,
+                source_url=page_url,
+            ),
+            "facility_type": "sento",
+        }
+
+    @staticmethod
+    def _is_pagination_url(url: str) -> bool:
+        return any(pattern.search(url) for pattern in _PAGINATION_PATTERNS)

--- a/batch/tests/test_yamanashi_parser.py
+++ b/batch/tests/test_yamanashi_parser.py
@@ -1,0 +1,139 @@
+"""YamanashiParser のユニットテスト。"""
+import pytest
+
+from parsers.yamanashi import YamanashiParser, LIST_URL
+
+
+@pytest.fixture
+def parser() -> YamanashiParser:
+    return YamanashiParser()
+
+
+def test_get_list_urls_returns_top(parser: YamanashiParser) -> None:
+    assert parser.get_list_urls() == [LIST_URL]
+
+
+YAMANASHI_LIST_HTML_PAGINATION = """
+<html>
+<body>
+  <a href="/page/2/">2</a>
+  <a href="https://sento-yamanashi.com/?paged=2">2(dup)</a>
+  <a href="/about/">about</a>
+</body>
+</html>
+"""
+
+
+def test_get_all_list_urls_collects_pagination(parser: YamanashiParser) -> None:
+    urls = parser.get_all_list_urls(YAMANASHI_LIST_HTML_PAGINATION)
+    assert LIST_URL in urls
+    assert "https://sento-yamanashi.com/page/2/" in urls
+    assert "https://sento-yamanashi.com/?paged=2" in urls
+
+
+YAMANASHI_LIST_HTML_ITEMS = """
+<html>
+<body>
+  <a href="/sento/fuji-yu/">富士湯</a>
+  <a href="/bath/kofu-onsen/">甲府温泉</a>
+  <a href="/page/2/">一覧2</a>
+  <a href="/category/news/">お知らせ</a>
+  <a href="https://example.com/elsewhere">外部</a>
+  <a href="/sento/fuji-yu/">富士湯(重複)</a>
+</body>
+</html>
+"""
+
+
+def test_get_item_urls_extracts_and_deduplicates(parser: YamanashiParser) -> None:
+    urls = parser.get_item_urls(YAMANASHI_LIST_HTML_ITEMS, LIST_URL)
+    assert len(urls) == 2
+    assert "https://sento-yamanashi.com/sento/fuji-yu/" in urls
+    assert "https://sento-yamanashi.com/bath/kofu-onsen/" in urls
+
+
+YAMANASHI_DETAIL_HTML_HAPPY = """
+<html>
+<body>
+  <h1 class="entry-title">富士湯</h1>
+  <dl>
+    <dt>住所</dt><dd>山梨県甲府市1-2-3</dd>
+    <dt>TEL</dt><dd>055-111-2222</dd>
+    <dt>営業時間</dt><dd>15:00〜23:00</dd>
+    <dt>定休日</dt><dd>月曜日</dd>
+  </dl>
+  <a href="https://www.google.com/maps?q=35.6668,138.5684">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_happy_path(parser: YamanashiParser) -> None:
+    url = "https://sento-yamanashi.com/sento/fuji-yu/"
+    result = parser.parse_sento(YAMANASHI_DETAIL_HTML_HAPPY, url)
+
+    assert result is not None
+    assert result["name"] == "富士湯"
+    assert result["address"] == "山梨県甲府市1-2-3"
+    assert result["phone"] == "055-111-2222"
+    assert result["open_hours"] == "15:00〜23:00"
+    assert result["holiday"] == "月曜日"
+    assert result["lat"] == pytest.approx(35.6668)
+    assert result["lng"] == pytest.approx(138.5684)
+    assert result["prefecture"] == "山梨県"
+    assert result["region"] == "中部"
+    assert result["facility_type"] == "sento"
+    assert result["source_url"] == url
+
+
+YAMANASHI_DETAIL_HTML_TEL_AND_DEST = """
+<html>
+<body>
+  <h1>甲府温泉</h1>
+  <table>
+    <tr><th>住所</th><td>山梨県甲府市4-5-6</td></tr>
+  </table>
+  <a href="tel:055-999-0000">電話</a>
+  <a href="https://www.google.com/maps?destination=35.6600,138.5600">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_tel_link_and_destination_coords(parser: YamanashiParser) -> None:
+    result = parser.parse_sento(
+        YAMANASHI_DETAIL_HTML_TEL_AND_DEST,
+        "https://sento-yamanashi.com/bath/kofu-onsen/",
+    )
+    assert result is not None
+    assert result["phone"] == "055-999-0000"
+    assert result["lat"] == pytest.approx(35.6600)
+    assert result["lng"] == pytest.approx(138.5600)
+
+
+YAMANASHI_DETAIL_HTML_NO_MAPS = """
+<html>
+<body>
+  <h1>石和の湯</h1>
+  <dl>
+    <dt>住所</dt><dd>山梨県笛吹市7-8-9</dd>
+  </dl>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_returns_none_coords_when_no_maps_link(parser: YamanashiParser) -> None:
+    result = parser.parse_sento(
+        YAMANASHI_DETAIL_HTML_NO_MAPS,
+        "https://sento-yamanashi.com/sento/isawa-no-yu/",
+    )
+    assert result is not None
+    assert result["lat"] is None
+    assert result["lng"] is None
+
+
+def test_parse_sento_returns_none_when_name_missing(parser: YamanashiParser) -> None:
+    html = "<html><body><p>not found</p></body></html>"
+    result = parser.parse_sento(html, "https://sento-yamanashi.com/sento/missing/")
+    assert result is None


### PR DESCRIPTION
## Summary
- `batch/parsers/yamanashi.py` 新規作成（sento-yamanashi.com）

## Test plan
- [x] `PARSERS["山梨県"]` が登録されていること（7テスト全パス）

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)