### PR TITLE
feat(EXPAND-niigata): 新潟県銭湯パーサー実装

### DIFF
--- a/batch/parsers/__init__.py
+++ b/batch/parsers/__init__.py
@@ -10,6 +10,7 @@ from parsers.hyogo import HyogoParser
 from parsers.saitama import SaitamaParser
 from parsers.chiba import ChibaParser
 from parsers.hokkaido import HokkaidoParser
+from parsers.niigata import NiigataParser
 
 PARSERS: dict[str, type[BaseParser]] = {
     "東京都": TokyoParser,
@@ -22,10 +23,11 @@ PARSERS: dict[str, type[BaseParser]] = {
     "埼玉県": SaitamaParser,
     "千葉県": ChibaParser,
     "北海道": HokkaidoParser,
+    "新潟県": NiigataParser,
 }
 
 __all__ = [
     "BaseParser", "TokyoParser", "KyotoParser", "FukuokaParser",
     "OsakaParser", "AichiParser", "KanagawaParser", "HyogoParser",
-    "SaitamaParser", "ChibaParser", "HokkaidoParser", "PARSERS",
+    "SaitamaParser", "ChibaParser", "HokkaidoParser", "NiigataParser", "PARSERS",
 ]

--- a/batch/parsers/niigata.py
+++ b/batch/parsers/niigata.py
@@ -1,0 +1,150 @@
+"""新潟県銭湯組合 (niigata1010.com) パーサー。"""
+import logging
+import re
+from typing import Optional
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+from parsers.base import BaseParser
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://niigata1010.com"
+LIST_URL = f"{BASE_URL}/sento-list/"
+
+# 個別ページの候補となる URL パターン
+_DETAIL_PATH_PATTERNS = (
+    re.compile(r"/sento/[^/?#]+/?$"),
+    re.compile(r"/sento_list/[^/?#]+/?$"),
+    re.compile(r"/bath/[^/?#]+/?$"),
+    re.compile(r"/\d{4}/\d{2}/[^/?#]+/?$"),
+)
+
+# 一覧・ナビゲーション等として除外する URL 文字列
+_EXCLUDED_PATH_KEYWORDS = (
+    "/sento-list/",
+    "/category/",
+    "/tag/",
+    "/author/",
+    "/page/",
+    "/news/",
+    "/about/",
+    "/contact/",
+    "/wp-admin",
+    "/wp-login",
+)
+
+_GMAPS_Q_PATTERN = re.compile(r"[?&]q=([-\d.]+)(?:%2C|,)([-\d.]+)")
+_DESTINATION_PATTERN = re.compile(r"destination=([-\d.]+)(?:%2C|,)([-\d.]+)")
+_GMAPS_LL_PATTERN = re.compile(r"[?&]ll=([-\d.]+)(?:%2C|,)([-\d.]+)")
+_GMAPS_AT_PATTERN = re.compile(r"/@([-\d.]+),([-\d.]+)")
+_GMAPS_3D4D_PATTERN = re.compile(r"!3d([-\d.]+)!4d([-\d.]+)")
+
+
+class NiigataParser(BaseParser):
+    prefecture = "新潟県"
+    region = "中部"
+
+    def get_list_urls(self) -> list[str]:
+        return [LIST_URL]
+
+    def get_item_urls(self, html: str, page_url: str) -> list[str]:
+        soup = BeautifulSoup(html, "lxml")
+        urls: list[str] = []
+        seen: set[str] = set()
+
+        for a in soup.find_all("a", href=True):
+            href = a["href"].strip()
+            if not href or href.startswith(("#", "javascript:")):
+                continue
+
+            if not href.startswith("http"):
+                href = urljoin(BASE_URL, href)
+
+            parsed = urlparse(href)
+            if parsed.netloc not in {"niigata1010.com", "www.niigata1010.com"}:
+                continue
+            if any(keyword in parsed.path for keyword in _EXCLUDED_PATH_KEYWORDS):
+                continue
+
+            if any(pat.search(parsed.path) for pat in _DETAIL_PATH_PATTERNS):
+                if href not in seen:
+                    seen.add(href)
+                    urls.append(href)
+
+        return urls
+
+    def parse_sento(self, html: str, page_url: str) -> Optional[dict]:
+        soup = BeautifulSoup(html, "lxml")
+
+        name: Optional[str] = None
+        for selector in ("h1.entry-title", "h1.post-title", "h1", "h2.entry-title", "h2"):
+            tag = soup.select_one(selector)
+            if not tag:
+                continue
+            raw = tag.get_text(strip=True)
+            if raw and len(raw) <= 80:
+                name = raw
+                break
+
+        if not name:
+            logger.warning("name が取得できません: %s", page_url)
+            return None
+
+        address = self.extract_label_value(soup, "住所") or self.extract_table_value(soup, "住所") or ""
+        phone = (
+            self.extract_label_value(soup, "TEL")
+            or self.extract_label_value(soup, "電話")
+            or self.extract_table_value(soup, "TEL")
+            or self.extract_table_value(soup, "電話")
+        )
+        open_hours = self.extract_label_value(soup, "営業時間") or self.extract_table_value(soup, "営業時間")
+        holiday = (
+            self.extract_label_value(soup, "定休日")
+            or self.extract_label_value(soup, "休日")
+            or self.extract_table_value(soup, "定休日")
+            or self.extract_table_value(soup, "休業日")
+            or self.extract_table_value(soup, "休日")
+        )
+
+        if not phone:
+            tel_tag = soup.find("a", href=re.compile(r"^tel:"))
+            if tel_tag:
+                phone = tel_tag["href"].replace("tel:", "").strip()
+
+        lat: Optional[float] = None
+        lng: Optional[float] = None
+        for maps_tag in soup.find_all("a", href=True):
+            href = maps_tag["href"]
+            if "google.com/maps" not in href and "maps.google." not in href:
+                continue
+
+            m = (
+                _GMAPS_Q_PATTERN.search(href)
+                or _DESTINATION_PATTERN.search(href)
+                or _GMAPS_LL_PATTERN.search(href)
+                or _GMAPS_AT_PATTERN.search(href)
+                or _GMAPS_3D4D_PATTERN.search(href)
+            )
+            if not m:
+                continue
+
+            try:
+                lat = float(m.group(1))
+                lng = float(m.group(2))
+                break
+            except ValueError:
+                continue
+
+        return self.make_sento_dict(
+            name=name,
+            address=address,
+            lat=lat,
+            lng=lng,
+            phone=phone,
+            open_hours=open_hours,
+            holiday=holiday,
+            source_url=page_url,
+            facility_type="sento",
+        )

--- a/batch/tests/test_niigata_parser.py
+++ b/batch/tests/test_niigata_parser.py
@@ -1,0 +1,148 @@
+"""NiigataParser のユニットテスト。"""
+import pytest
+
+from parsers import PARSERS
+from parsers.niigata import NiigataParser
+
+
+@pytest.fixture
+def parser() -> NiigataParser:
+    return NiigataParser()
+
+
+def test_get_list_urls(parser: NiigataParser) -> None:
+    urls = parser.get_list_urls()
+    assert urls == ["https://niigata1010.com/sento-list/"]
+
+
+NIIGATA_LIST_HTML = """
+<html>
+<body>
+  <a href="/sento/matsu-yu/">松の湯</a>
+  <a href="https://niigata1010.com/sento_list/ume-yu/">梅の湯</a>
+  <a href="https://www.niigata1010.com/bath/take-yu/">竹の湯</a>
+  <a href="/sento-list/">一覧（除外）</a>
+  <a href="/category/news/">カテゴリ（除外）</a>
+  <a href="https://example.com/sento/outside/">外部（除外）</a>
+  <a href="/sento/matsu-yu/">重複</a>
+</body>
+</html>
+"""
+
+
+def test_get_item_urls_extracts_and_deduplicates(parser: NiigataParser) -> None:
+    urls = parser.get_item_urls(NIIGATA_LIST_HTML, "https://niigata1010.com/sento-list/")
+    assert urls == [
+        "https://niigata1010.com/sento/matsu-yu/",
+        "https://niigata1010.com/sento_list/ume-yu/",
+        "https://www.niigata1010.com/bath/take-yu/",
+    ]
+
+
+NIIGATA_DETAIL_HTML_HAPPY = """
+<html>
+<body>
+  <h1>松の湯</h1>
+  <dl>
+    <dt>住所</dt><dd>新潟県新潟市中央区1-2-3</dd>
+    <dt>TEL</dt><dd>025-111-2222</dd>
+    <dt>営業時間</dt><dd>15:00〜23:00</dd>
+    <dt>定休日</dt><dd>火曜日</dd>
+  </dl>
+  <a href="https://www.google.com/maps?q=37.9026,139.0232">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_happy_path(parser: NiigataParser) -> None:
+    result = parser.parse_sento(NIIGATA_DETAIL_HTML_HAPPY, "https://niigata1010.com/sento/matsu-yu/")
+
+    assert result is not None
+    assert result["name"] == "松の湯"
+    assert result["address"] == "新潟県新潟市中央区1-2-3"
+    assert result["phone"] == "025-111-2222"
+    assert result["open_hours"] == "15:00〜23:00"
+    assert result["holiday"] == "火曜日"
+    assert result["lat"] == pytest.approx(37.9026)
+    assert result["lng"] == pytest.approx(139.0232)
+    assert result["prefecture"] == "新潟県"
+    assert result["region"] == "中部"
+    assert result["facility_type"] == "sento"
+    assert result["source_url"] == "https://niigata1010.com/sento/matsu-yu/"
+
+
+NIIGATA_DETAIL_HTML_DESTINATION = """
+<html>
+<body>
+  <h1>梅の湯</h1>
+  <dl>
+    <dt>住所</dt><dd>新潟県長岡市4-5-6</dd>
+  </dl>
+  <a href="https://www.google.com/maps/dir/?api=1&destination=37.4462,138.8512">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_coords_from_destination(parser: NiigataParser) -> None:
+    result = parser.parse_sento(NIIGATA_DETAIL_HTML_DESTINATION, "https://niigata1010.com/sento/ume-yu/")
+    assert result is not None
+    assert result["lat"] == pytest.approx(37.4462)
+    assert result["lng"] == pytest.approx(138.8512)
+
+
+NIIGATA_DETAIL_HTML_NO_COORDS = """
+<html>
+<body>
+  <h1>竹の湯</h1>
+  <dl>
+    <dt>住所</dt><dd>新潟県上越市7-8-9</dd>
+    <dt>営業時間</dt><dd>14:00〜22:00</dd>
+  </dl>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_returns_none_coords_when_map_missing(parser: NiigataParser) -> None:
+    result = parser.parse_sento(NIIGATA_DETAIL_HTML_NO_COORDS, "https://niigata1010.com/sento/take-yu/")
+    assert result is not None
+    assert result["lat"] is None
+    assert result["lng"] is None
+
+
+NIIGATA_DETAIL_HTML_TEL_LINK = """
+<html>
+<body>
+  <h1>桜湯</h1>
+  <table>
+    <tr><th>住所</th><td>新潟県三条市1-1-1</td></tr>
+    <tr><th>休業日</th><td>月曜日</td></tr>
+  </table>
+  <a href="tel:0256-22-3344">電話</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_phone_from_tel_and_table_fields(parser: NiigataParser) -> None:
+    result = parser.parse_sento(NIIGATA_DETAIL_HTML_TEL_LINK, "https://niigata1010.com/sento/sakura-yu/")
+    assert result is not None
+    assert result["address"] == "新潟県三条市1-1-1"
+    assert result["phone"] == "0256-22-3344"
+    assert result["holiday"] == "月曜日"
+
+
+def test_parse_sento_returns_none_when_name_missing(parser: NiigataParser) -> None:
+    html = """
+    <html><body>
+      <dl><dt>住所</dt><dd>新潟県</dd></dl>
+    </body></html>
+    """
+    assert parser.parse_sento(html, "https://niigata1010.com/sento/unknown/") is None
+
+
+def test_parser_registered_in_parsers_dict() -> None:
+    assert "新潟県" in PARSERS
+    assert PARSERS["新潟県"] is NiigataParser


### PR DESCRIPTION
## Summary
- `batch/parsers/niigata.py` 新規作成（niigata1010.com）

## Test plan
- [x] `PARSERS["新潟県"]` が登録されていること（8テスト全パス）

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)