### PR TITLE
feat(EXPAND-ishikawa): 石川県銭湯パーサー実装

### DIFF
--- a/batch/parsers/__init__.py
+++ b/batch/parsers/__init__.py
@@ -10,6 +10,7 @@ from parsers.hyogo import HyogoParser
 from parsers.saitama import SaitamaParser
 from parsers.chiba import ChibaParser
 from parsers.hokkaido import HokkaidoParser
+from parsers.ishikawa import IshikawaParser
 
 PARSERS: dict[str, type[BaseParser]] = {
     "東京都": TokyoParser,
@@ -22,10 +23,11 @@ PARSERS: dict[str, type[BaseParser]] = {
     "埼玉県": SaitamaParser,
     "千葉県": ChibaParser,
     "北海道": HokkaidoParser,
+    "石川県": IshikawaParser,
 }
 
 __all__ = [
     "BaseParser", "TokyoParser", "KyotoParser", "FukuokaParser",
     "OsakaParser", "AichiParser", "KanagawaParser", "HyogoParser",
-    "SaitamaParser", "ChibaParser", "HokkaidoParser", "PARSERS",
+    "SaitamaParser", "ChibaParser", "HokkaidoParser", "IshikawaParser", "PARSERS",
 ]

--- a/batch/parsers/ishikawa.py
+++ b/batch/parsers/ishikawa.py
@@ -1,0 +1,253 @@
+"""石川県銭湯組合 (ishikawa1010.com) パーサー。
+
+HTML 構造（想定）:
+- 一覧/地図: https://ishikawa1010.com/bath
+  - 個別リンク: /bath/{ID}
+  - 座標: data-lat/data-lng または JavaScript 変数（lat/lng）に埋め込み
+- 個別: /bath/{ID}
+  - 銭湯名: h1/h2
+  - 住所・電話・営業時間・定休日: dt/dd ペア
+  - 座標: Google Maps embed/link または JavaScript 変数
+"""
+import logging
+import re
+from typing import Optional
+from urllib.parse import unquote, urljoin, urlparse, urlunparse
+
+from bs4 import BeautifulSoup
+from bs4.element import Tag
+
+from parsers.base import BaseParser
+from parsers.utils import extract_label_value
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://ishikawa1010.com"
+LIST_URL = f"{BASE_URL}/bath"
+
+_DETAIL_URL_PATH_PATTERN = re.compile(r"^/bath/\d+/?$")
+_DETAIL_URL_IN_HTML_PATTERN = re.compile(r"(?:https?://[^\"'\s]+)?/bath/\d+/?")
+
+_GMAPS_Q_PATTERN = re.compile(r"[?&]q=([-\d.]+),([-\d.]+)")
+_GMAPS_LL_PATTERN = re.compile(r"[?&]ll=([-\d.]+),([-\d.]+)")
+_GMAPS_DESTINATION_PATTERN = re.compile(r"destination=([-\d.]+),([-\d.]+)")
+_GMAPS_CENTER_PATTERN = re.compile(r"center=([-\d.]+)(?:,|%2C)([-\d.]+)")
+_GMAPS_EMBED_3D4D_PATTERN = re.compile(r"!3d([-\d.]+)!4d([-\d.]+)")
+_GMAPS_EMBED_2D3D_PATTERN = re.compile(r"!2d([-\d.]+)!3d([-\d.]+)")
+_GMAPS_URL_PATTERN = re.compile(r"https?://(?:www\.)?google\.[^\"'\s]+/maps[^\"'\s]*")
+
+_LAT_VALUE_PATTERN = re.compile(r"(?:[\"']?(?:lat|latitude)[\"']?)\s*[:=]\s*[\"']?([-\d.]+)")
+_LNG_VALUE_PATTERN = re.compile(r"(?:[\"']?(?:lng|lon|longitude)[\"']?)\s*[:=]\s*[\"']?([-\d.]+)")
+
+
+class IshikawaParser(BaseParser):
+    prefecture = "石川県"
+    region = "中部"
+
+    def __init__(self) -> None:
+        # source_url -> (lat, lng)
+        self._coord_cache: dict[str, tuple[float, float]] = {}
+
+    def get_list_urls(self) -> list[str]:
+        return [LIST_URL]
+
+    def get_item_urls(self, html: str, page_url: str) -> list[str]:
+        soup = BeautifulSoup(html, "lxml")
+        urls: list[str] = []
+        seen: set[str] = set()
+
+        # 1) a タグから個別 URL を抽出（data-* 座標があればキャッシュ）
+        for a in soup.find_all("a", href=True):
+            normalized = self._normalize_detail_url(a["href"])
+            if not normalized:
+                continue
+            if normalized not in seen:
+                seen.add(normalized)
+                urls.append(normalized)
+
+            coords = self._extract_coords_from_tag_context(a)
+            if coords:
+                self._coord_cache[normalized] = coords
+
+        # 2) JS から個別 URL / 座標を抽出
+        for m in _DETAIL_URL_IN_HTML_PATTERN.finditer(html):
+            normalized = self._normalize_detail_url(m.group(0))
+            if not normalized:
+                continue
+            if normalized not in seen:
+                seen.add(normalized)
+                urls.append(normalized)
+
+            # URL 近傍のテキストから lat/lng もしくは Google Maps URL を抽出
+            coords = self._extract_coords_from_object_near(html, m.start(), m.end())
+            if not coords:
+                start = max(0, m.start() - 400)
+                end = min(len(html), m.end() + 400)
+                coords = self._extract_coords_from_text(html[start:end])
+            if coords and normalized not in self._coord_cache:
+                self._coord_cache[normalized] = coords
+
+        return urls
+
+    def parse_sento(self, html: str, page_url: str) -> Optional[dict]:
+        soup = BeautifulSoup(html, "lxml")
+        normalized_page_url = self._normalize_detail_url(page_url) or page_url
+
+        name: Optional[str] = None
+        for selector in ("h1.entry-title", "h1", "h2"):
+            tag = soup.select_one(selector)
+            if tag:
+                raw = tag.get_text(strip=True)
+                if raw and len(raw) < 60:
+                    name = raw
+                    break
+        if not name:
+            logger.warning("name が取得できません: %s", page_url)
+            return None
+
+        address = extract_label_value(soup, "住所") or ""
+        phone = extract_label_value(soup, "TEL") or extract_label_value(soup, "電話")
+        if not phone:
+            tel_tag = soup.find("a", href=re.compile(r"^tel:"))
+            if tel_tag:
+                phone = tel_tag["href"].replace("tel:", "").strip()
+        open_hours = extract_label_value(soup, "営業時間")
+        holiday = extract_label_value(soup, "定休日") or extract_label_value(soup, "休日")
+
+        lat: Optional[float] = None
+        lng: Optional[float] = None
+
+        cached = self._coord_cache.get(normalized_page_url)
+        if cached:
+            lat, lng = cached
+
+        if lat is None:
+            for tag in soup.find_all(["a", "iframe"]):
+                src_or_href = tag.get("href") or tag.get("src")
+                if not src_or_href:
+                    continue
+                coords = self._extract_coords_from_google_maps_url(src_or_href)
+                if coords:
+                    lat, lng = coords
+                    break
+
+        if lat is None:
+            coords = self._extract_coords_from_text(html)
+            if coords:
+                lat, lng = coords
+
+        return {
+            **self.make_sento_dict(
+                name=name,
+                address=address,
+                lat=lat,
+                lng=lng,
+                phone=phone,
+                open_hours=open_hours,
+                holiday=holiday,
+                source_url=normalized_page_url,
+            ),
+            "facility_type": "sento",
+        }
+
+    def _normalize_detail_url(self, raw_url: str) -> Optional[str]:
+        url = urljoin(BASE_URL, raw_url)
+        parsed = urlparse(url)
+        if not _DETAIL_URL_PATH_PATTERN.match(parsed.path):
+            return None
+
+        path = parsed.path.rstrip("/") + "/"
+        normalized = urlunparse(("https", "ishikawa1010.com", path, "", "", ""))
+        return normalized
+
+    def _extract_coords_from_tag_context(self, tag: Tag) -> Optional[tuple[float, float]]:
+        for node in (tag, tag.parent):
+            if not isinstance(node, Tag):
+                continue
+
+            attr_pairs = [
+                ("data-lat", "data-lng"),
+                ("data-lat", "data-lon"),
+                ("data-latitude", "data-longitude"),
+                ("lat", "lng"),
+                ("latitude", "longitude"),
+            ]
+            for lat_key, lng_key in attr_pairs:
+                lat_raw = node.attrs.get(lat_key)
+                lng_raw = node.attrs.get(lng_key)
+                coords = self._to_coord_pair(lat_raw, lng_raw)
+                if coords:
+                    return coords
+
+            for attr_val in node.attrs.values():
+                if isinstance(attr_val, str):
+                    coords = self._extract_coords_from_google_maps_url(attr_val)
+                    if coords:
+                        return coords
+                    coords = self._extract_coords_from_text(attr_val)
+                    if coords:
+                        return coords
+
+        return None
+
+    def _extract_coords_from_google_maps_url(self, raw_url: str) -> Optional[tuple[float, float]]:
+        if "google" not in raw_url or "maps" not in raw_url:
+            return None
+
+        decoded = unquote(raw_url)
+        for pattern in (
+            _GMAPS_Q_PATTERN,
+            _GMAPS_DESTINATION_PATTERN,
+            _GMAPS_LL_PATTERN,
+            _GMAPS_CENTER_PATTERN,
+            _GMAPS_EMBED_3D4D_PATTERN,
+        ):
+            m = pattern.search(decoded)
+            if m:
+                coords = self._to_coord_pair(m.group(1), m.group(2))
+                if coords:
+                    return coords
+        m_embed_2d3d = _GMAPS_EMBED_2D3D_PATTERN.search(decoded)
+        if m_embed_2d3d:
+            # !2d{lng}!3d{lat} の順序で埋め込まれる形式
+            coords = self._to_coord_pair(m_embed_2d3d.group(2), m_embed_2d3d.group(1))
+            if coords:
+                return coords
+        return None
+
+    def _extract_coords_from_text(self, text: str) -> Optional[tuple[float, float]]:
+        # Google Maps URL を優先（実際の表示座標を拾いやすいため）
+        for m in _GMAPS_URL_PATTERN.finditer(text):
+            coords = self._extract_coords_from_google_maps_url(m.group(0))
+            if coords:
+                return coords
+
+        lat_match = _LAT_VALUE_PATTERN.search(text)
+        lng_match = _LNG_VALUE_PATTERN.search(text)
+        if lat_match and lng_match:
+            return self._to_coord_pair(lat_match.group(1), lng_match.group(1))
+        return None
+
+    def _extract_coords_from_object_near(
+        self,
+        text: str,
+        match_start: int,
+        match_end: int,
+    ) -> Optional[tuple[float, float]]:
+        """URL を含む JS オブジェクト断片から優先的に座標を抽出する。"""
+        obj_start = text.rfind("{", max(0, match_start - 300), match_start + 1)
+        obj_end = text.find("}", match_end, min(len(text), match_end + 300))
+        if obj_start == -1 or obj_end == -1 or obj_end <= obj_start:
+            return None
+        return self._extract_coords_from_text(text[obj_start:obj_end + 1])
+
+    def _to_coord_pair(self, lat_raw: object, lng_raw: object) -> Optional[tuple[float, float]]:
+        try:
+            lat = float(str(lat_raw))
+            lng = float(str(lng_raw))
+        except (TypeError, ValueError):
+            return None
+
+        if not (-90 <= lat <= 90 and -180 <= lng <= 180):
+            return None
+        return lat, lng

--- a/batch/tests/test_ishikawa_parser.py
+++ b/batch/tests/test_ishikawa_parser.py
@@ -1,0 +1,158 @@
+"""IshikawaParser のユニットテスト。"""
+import pytest
+
+from parsers.ishikawa import IshikawaParser
+
+
+@pytest.fixture
+def parser() -> IshikawaParser:
+    return IshikawaParser()
+
+
+def test_get_list_urls(parser: IshikawaParser) -> None:
+    assert parser.get_list_urls() == ["https://ishikawa1010.com/bath"]
+
+
+ISHIKAWA_LIST_HTML_DATA_ATTR = """
+<html>
+<body>
+  <a href="/bath/21" data-lat="36.5610" data-lng="136.6562">松の湯</a>
+  <a href="https://ishikawa1010.com/bath/22/" data-lat="36.5700" data-lng="136.6600">梅の湯</a>
+  <a href="/bath/21">松の湯（重複）</a>
+  <a href="/bath">一覧</a>
+</body>
+</html>
+"""
+
+
+def test_get_item_urls_extracts_and_deduplicates(parser: IshikawaParser) -> None:
+    urls = parser.get_item_urls(ISHIKAWA_LIST_HTML_DATA_ATTR, "https://ishikawa1010.com/bath")
+    assert urls == [
+        "https://ishikawa1010.com/bath/21/",
+        "https://ishikawa1010.com/bath/22/",
+    ]
+
+
+def test_get_item_urls_caches_coords_from_data_attrs(parser: IshikawaParser) -> None:
+    parser.get_item_urls(ISHIKAWA_LIST_HTML_DATA_ATTR, "https://ishikawa1010.com/bath")
+
+    assert parser._coord_cache["https://ishikawa1010.com/bath/21/"] == pytest.approx((36.5610, 136.6562))
+    assert parser._coord_cache["https://ishikawa1010.com/bath/22/"] == pytest.approx((36.5700, 136.6600))
+
+
+ISHIKAWA_LIST_HTML_JS = """
+<html>
+<body>
+  <script>
+    const sentoMarkers = [
+      { "url": "/bath/31", "lat": "36.5801", "lng": "136.6702" },
+      { "link": "/bath/32", "mapUrl": "https://www.google.com/maps?q=36.5903,136.6804" }
+    ];
+  </script>
+</body>
+</html>
+"""
+
+
+def test_get_item_urls_extracts_urls_and_coords_from_js(parser: IshikawaParser) -> None:
+    urls = parser.get_item_urls(ISHIKAWA_LIST_HTML_JS, "https://ishikawa1010.com/bath")
+
+    assert "https://ishikawa1010.com/bath/31/" in urls
+    assert "https://ishikawa1010.com/bath/32/" in urls
+    assert parser._coord_cache["https://ishikawa1010.com/bath/31/"] == pytest.approx((36.5801, 136.6702))
+    assert parser._coord_cache["https://ishikawa1010.com/bath/32/"] == pytest.approx((36.5903, 136.6804))
+
+
+ISHIKAWA_DETAIL_HTML_HAPPY = """
+<html>
+<body>
+  <h1>松の湯</h1>
+  <dl>
+    <dt>住所</dt><dd>石川県金沢市1-2-3</dd>
+    <dt>TEL</dt><dd>076-111-2222</dd>
+    <dt>営業時間</dt><dd>14:00〜23:00</dd>
+    <dt>定休日</dt><dd>月曜日</dd>
+  </dl>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_uses_cached_coords(parser: IshikawaParser) -> None:
+    url = "https://ishikawa1010.com/bath/21/"
+    parser._coord_cache[url] = (36.5610, 136.6562)
+
+    result = parser.parse_sento(ISHIKAWA_DETAIL_HTML_HAPPY, url)
+
+    assert result is not None
+    assert result["name"] == "松の湯"
+    assert result["address"] == "石川県金沢市1-2-3"
+    assert result["phone"] == "076-111-2222"
+    assert result["open_hours"] == "14:00〜23:00"
+    assert result["holiday"] == "月曜日"
+    assert result["lat"] == pytest.approx(36.5610)
+    assert result["lng"] == pytest.approx(136.6562)
+    assert result["prefecture"] == "石川県"
+    assert result["region"] == "中部"
+    assert result["facility_type"] == "sento"
+    assert result["source_url"] == url
+
+
+ISHIKAWA_DETAIL_HTML_IFRAME = """
+<html>
+<body>
+  <h1>竹の湯</h1>
+  <dl><dt>住所</dt><dd>石川県金沢市4-5-6</dd></dl>
+  <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1012!2d136.7000!3d36.6000"></iframe>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_coords_from_google_embed(parser: IshikawaParser) -> None:
+    result = parser.parse_sento(ISHIKAWA_DETAIL_HTML_IFRAME, "https://ishikawa1010.com/bath/40")
+    assert result is not None
+    assert result["lat"] == pytest.approx(36.6000)
+    assert result["lng"] == pytest.approx(136.7000)
+
+
+ISHIKAWA_DETAIL_HTML_JS_COORDS = """
+<html>
+<body>
+  <h2>桜の湯</h2>
+  <dl><dt>住所</dt><dd>石川県小松市7-8-9</dd></dl>
+  <script>
+    window.sentoPoint = { lat: 36.6123, lng: 136.7123 };
+  </script>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_coords_from_js_variable(parser: IshikawaParser) -> None:
+    result = parser.parse_sento(ISHIKAWA_DETAIL_HTML_JS_COORDS, "https://ishikawa1010.com/bath/41")
+    assert result is not None
+    assert result["lat"] == pytest.approx(36.6123)
+    assert result["lng"] == pytest.approx(136.7123)
+
+
+def test_parse_sento_returns_none_when_name_missing(parser: IshikawaParser) -> None:
+    html = """
+    <html><body><p>情報なし</p></body></html>
+    """
+    assert parser.parse_sento(html, "https://ishikawa1010.com/bath/99") is None
+
+
+def test_parse_sento_keeps_lat_lng_none_when_not_found(parser: IshikawaParser) -> None:
+    html = """
+    <html>
+    <body>
+      <h1>謎の湯</h1>
+      <dl><dt>住所</dt><dd>石川県白山市1-1</dd></dl>
+    </body>
+    </html>
+    """
+    result = parser.parse_sento(html, "https://ishikawa1010.com/bath/42")
+    assert result is not None
+    assert result["lat"] is None
+    assert result["lng"] is None


### PR DESCRIPTION
## Summary
- `batch/parsers/ishikawa.py` 新規作成（ishikawa1010.jp 地図ページ・JS変数座標対応）

## Test plan
- [x] `PARSERS["石川県"]` が登録されていること（9テスト全パス）

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)