### PR TITLE
feat(EXPAND-fukui): 福井県銭湯パーサー実装

### DIFF
--- a/batch/parsers/__init__.py
+++ b/batch/parsers/__init__.py
@@ -10,6 +10,7 @@ from parsers.hyogo import HyogoParser
 from parsers.saitama import SaitamaParser
 from parsers.chiba import ChibaParser
 from parsers.hokkaido import HokkaidoParser
+from parsers.fukui import FukuiParser
 
 PARSERS: dict[str, type[BaseParser]] = {
     "東京都": TokyoParser,
@@ -22,10 +23,11 @@ PARSERS: dict[str, type[BaseParser]] = {
     "埼玉県": SaitamaParser,
     "千葉県": ChibaParser,
     "北海道": HokkaidoParser,
+    "福井県": FukuiParser,
 }
 
 __all__ = [
     "BaseParser", "TokyoParser", "KyotoParser", "FukuokaParser",
     "OsakaParser", "AichiParser", "KanagawaParser", "HyogoParser",
-    "SaitamaParser", "ChibaParser", "HokkaidoParser", "PARSERS",
+    "SaitamaParser", "ChibaParser", "HokkaidoParser", "FukuiParser", "PARSERS",
 ]

--- a/batch/parsers/fukui.py
+++ b/batch/parsers/fukui.py
@@ -1,0 +1,170 @@
+"""福井県銭湯 (fukui1010.com) パーサー。"""
+import logging
+import re
+from typing import Optional
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+from parsers.base import BaseParser
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://fukui1010.com"
+LIST_URL = BASE_URL + "/"
+
+_COORD_Q_PATTERN = re.compile(r"[?&]q=([\-\d.]+),([\-\d.]+)")
+_COORD_LL_PATTERN = re.compile(r"[?&]ll=([\-\d.]+),([\-\d.]+)")
+_COORD_DEST_PATTERN = re.compile(r"[?&]destination=([\-\d.]+),([\-\d.]+)")
+_COORD_AT_PATTERN = re.compile(r"@([\-\d.]+),([\-\d.]+)")
+_COORD_EMBED_PATTERN = re.compile(r"!3d([\-\d.]+)!4d([\-\d.]+)")
+_COORD_EMBED_2D3D_PATTERN = re.compile(r"!2d([\-\d.]+)!3d([\-\d.]+)")
+
+
+class FukuiParser(BaseParser):
+    prefecture = "福井県"
+    region = "中部"
+
+    def get_list_urls(self) -> list[str]:
+        return [LIST_URL]
+
+    def get_item_urls(self, html: str, page_url: str) -> list[str]:
+        soup = BeautifulSoup(html, "lxml")
+        urls: list[str] = []
+        seen: set[str] = set()
+
+        for a in soup.find_all("a", href=True):
+            href = str(a["href"]).strip()
+            if not href or href.startswith(("#", "javascript:", "mailto:", "tel:")):
+                continue
+
+            full_url = urljoin(BASE_URL, href)
+            parsed = urlparse(full_url)
+            if "fukui1010.com" not in parsed.netloc:
+                continue
+
+            path = parsed.path.rstrip("/").lower()
+            if not path or path in {"", "/"}:
+                continue
+
+            # 一覧や案内ページを除き、銭湯詳細と推定できるリンクのみ対象にする。
+            text = a.get_text(" ", strip=True)
+            is_detail_like = (
+                any(token in path for token in ("/sento/", "/bath/", "/shop/", "/store/", "/spot/"))
+                or any(token in text for token in ("銭湯", "湯", "温泉"))
+            )
+            if not is_detail_like:
+                continue
+
+            if full_url not in seen:
+                seen.add(full_url)
+                urls.append(full_url)
+
+        return urls
+
+    def parse_sento(self, html: str, page_url: str) -> Optional[dict]:
+        soup = BeautifulSoup(html, "lxml")
+
+        name: Optional[str] = None
+        for selector in ("h1", "h2", ".entry-title", ".post-title"):
+            tag = soup.select_one(selector)
+            if not tag:
+                continue
+            raw = tag.get_text(" ", strip=True)
+            if raw and len(raw) < 80:
+                name = re.sub(r"\s*[\[【].+?[\]】]\s*$", "", raw).strip()
+                break
+        if not name:
+            logger.warning("name が取得できません: %s", page_url)
+            return None
+
+        address = (
+            self.extract_label_value(soup, "住所")
+            or self.extract_label_value(soup, "所在地")
+            or self.extract_table_value(soup, "住所")
+            or self.extract_table_value(soup, "所在地")
+            or ""
+        )
+        if not address:
+            for candidate in soup.stripped_strings:
+                if "福井県" in candidate:
+                    address = candidate.strip()
+                    break
+
+        phone = (
+            self.extract_label_value(soup, "TEL")
+            or self.extract_label_value(soup, "電話")
+            or self.extract_table_value(soup, "TEL")
+            or self.extract_table_value(soup, "電話")
+        )
+        if not phone:
+            tel_tag = soup.find("a", href=re.compile(r"^tel:"))
+            if tel_tag:
+                phone = str(tel_tag["href"]).replace("tel:", "").strip()
+
+        open_hours = (
+            self.extract_label_value(soup, "営業時間")
+            or self.extract_label_value(soup, "営業")
+            or self.extract_table_value(soup, "営業時間")
+            or self.extract_table_value(soup, "営業")
+        )
+        holiday = (
+            self.extract_label_value(soup, "定休日")
+            or self.extract_label_value(soup, "休日")
+            or self.extract_label_value(soup, "休業日")
+            or self.extract_table_value(soup, "定休日")
+            or self.extract_table_value(soup, "休日")
+            or self.extract_table_value(soup, "休業日")
+        )
+
+        lat: Optional[float] = None
+        lng: Optional[float] = None
+        for tag in soup.find_all(["a", "iframe"], href=True) + soup.find_all("iframe", src=True):
+            url = tag.get("href") or tag.get("src")
+            if not url:
+                continue
+            coord = _extract_coords_from_maps_url(str(url))
+            if coord:
+                lat, lng = coord
+                break
+
+        return self.make_sento_dict(
+            name=name,
+            address=address,
+            lat=lat,
+            lng=lng,
+            phone=phone,
+            open_hours=open_hours,
+            holiday=holiday,
+            source_url=page_url,
+            facility_type="sento",
+        )
+
+
+def _extract_coords_from_maps_url(url: str) -> Optional[tuple[float, float]]:
+    if "google.com/maps" not in url and "maps.app.goo.gl" not in url:
+        return None
+
+    for pattern in (
+        _COORD_Q_PATTERN,
+        _COORD_LL_PATTERN,
+        _COORD_DEST_PATTERN,
+        _COORD_AT_PATTERN,
+        _COORD_EMBED_PATTERN,
+    ):
+        m = pattern.search(url)
+        if not m:
+            continue
+        try:
+            return float(m.group(1)), float(m.group(2))
+        except ValueError:
+            return None
+
+    m = _COORD_EMBED_2D3D_PATTERN.search(url)
+    if m:
+        try:
+            return float(m.group(2)), float(m.group(1))
+        except ValueError:
+            return None
+
+    return None

--- a/batch/tests/test_fukui_parser.py
+++ b/batch/tests/test_fukui_parser.py
@@ -1,0 +1,123 @@
+"""FukuiParser のユニットテスト。"""
+import pytest
+
+from parsers.fukui import FukuiParser, _extract_coords_from_maps_url
+
+
+@pytest.fixture
+def parser() -> FukuiParser:
+    return FukuiParser()
+
+
+def test_get_list_urls(parser: FukuiParser) -> None:
+    assert parser.get_list_urls() == ["https://fukui1010.com/"]
+
+
+def test_get_item_urls_collects_detail_links(parser: FukuiParser) -> None:
+    html = """
+    <html><body>
+      <a href="/sento/matsu-no-yu/">松の湯</a>
+      <a href="https://fukui1010.com/bath/ume-no-yu/">梅の湯</a>
+      <a href="/about/">このサイトについて</a>
+      <a href="https://example.com/sento/foo/">外部</a>
+    </body></html>
+    """
+    urls = parser.get_item_urls(html, "https://fukui1010.com/")
+    assert urls == [
+        "https://fukui1010.com/sento/matsu-no-yu/",
+        "https://fukui1010.com/bath/ume-no-yu/",
+    ]
+
+
+def test_get_item_urls_deduplicates(parser: FukuiParser) -> None:
+    html = """
+    <html><body>
+      <a href="/sento/matsu-no-yu/">松の湯</a>
+      <a href="https://fukui1010.com/sento/matsu-no-yu/">松の湯(重複)</a>
+    </body></html>
+    """
+    urls = parser.get_item_urls(html, "https://fukui1010.com/")
+    assert len(urls) == 1
+
+
+def test_parse_sento_happy_path(parser: FukuiParser) -> None:
+    html = """
+    <html><body>
+      <h1>松の湯【福井市】</h1>
+      <dl>
+        <dt>住所</dt><dd>福井県福井市中央1-2-3</dd>
+        <dt>TEL</dt><dd>0776-11-2222</dd>
+        <dt>営業時間</dt><dd>15:00-23:00</dd>
+        <dt>定休日</dt><dd>月曜日</dd>
+      </dl>
+      <a href="https://www.google.com/maps?q=36.0641,136.2196">地図</a>
+    </body></html>
+    """
+
+    result = parser.parse_sento(html, "https://fukui1010.com/sento/matsu-no-yu/")
+
+    assert result is not None
+    assert result["name"] == "松の湯"
+    assert result["address"] == "福井県福井市中央1-2-3"
+    assert result["phone"] == "0776-11-2222"
+    assert result["open_hours"] == "15:00-23:00"
+    assert result["holiday"] == "月曜日"
+    assert result["lat"] == pytest.approx(36.0641)
+    assert result["lng"] == pytest.approx(136.2196)
+    assert result["prefecture"] == "福井県"
+    assert result["region"] == "中部"
+    assert result["facility_type"] == "sento"
+
+
+def test_parse_sento_destination_coords_and_tel_link(parser: FukuiParser) -> None:
+    html = """
+    <html><body>
+      <h2>梅の湯</h2>
+      <table>
+        <tr><th>所在地</th><td>福井県坂井市1-2</td></tr>
+        <tr><th>営業</th><td>16:00-22:30</td></tr>
+        <tr><th>休業日</th><td>木曜日</td></tr>
+      </table>
+      <a href="tel:0776-33-4444">電話</a>
+      <a href="https://www.google.com/maps/dir/?api=1&destination=36.2123,136.1478">地図</a>
+    </body></html>
+    """
+
+    result = parser.parse_sento(html, "https://fukui1010.com/sento/ume-no-yu/")
+
+    assert result is not None
+    assert result["address"] == "福井県坂井市1-2"
+    assert result["phone"] == "0776-33-4444"
+    assert result["open_hours"] == "16:00-22:30"
+    assert result["holiday"] == "木曜日"
+    assert result["lat"] == pytest.approx(36.2123)
+    assert result["lng"] == pytest.approx(136.1478)
+
+
+def test_parse_sento_lat_lng_none_when_no_maps_link(parser: FukuiParser) -> None:
+    html = """
+    <html><body>
+      <h1>竹の湯</h1>
+      <p>福井県越前市2-3-4</p>
+    </body></html>
+    """
+    result = parser.parse_sento(html, "https://fukui1010.com/sento/take-no-yu/")
+    assert result is not None
+    assert result["lat"] is None
+    assert result["lng"] is None
+
+
+def test_parse_sento_returns_none_when_name_missing(parser: FukuiParser) -> None:
+    html = """
+    <html><body>
+      <p>福井県福井市1-2-3</p>
+      <a href="https://www.google.com/maps?q=36.0,136.0">地図</a>
+    </body></html>
+    """
+    assert parser.parse_sento(html, "https://fukui1010.com/sento/unknown/") is None
+
+
+def test_extract_coords_from_maps_url_embed_pattern() -> None:
+    url = "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d1!2d136.5544!3d35.9422!2m3!1f0!2f0!3f0"
+    lat_lng = _extract_coords_from_maps_url(url)
+    assert lat_lng == pytest.approx((35.9422, 136.5544))


### PR DESCRIPTION
## Summary
- `batch/parsers/fukui.py` 新規作成（fukui1010.com 静的HTML）

## Test plan
- [x] `PARSERS["福井県"]` が登録されていること（8テスト全パス）

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)