### PR TITLE
feat(EXPAND-gifu): 岐阜県銭湯パーサー実装

### DIFF
--- a/batch/parsers/__init__.py
+++ b/batch/parsers/__init__.py
@@ -10,6 +10,7 @@ from parsers.hyogo import HyogoParser
 from parsers.saitama import SaitamaParser
 from parsers.chiba import ChibaParser
 from parsers.hokkaido import HokkaidoParser
+from parsers.gifu import GifuParser
 
 PARSERS: dict[str, type[BaseParser]] = {
     "東京都": TokyoParser,
@@ -22,10 +23,11 @@ PARSERS: dict[str, type[BaseParser]] = {
     "埼玉県": SaitamaParser,
     "千葉県": ChibaParser,
     "北海道": HokkaidoParser,
+    "岐阜県": GifuParser,
 }
 
 __all__ = [
     "BaseParser", "TokyoParser", "KyotoParser", "FukuokaParser",
     "OsakaParser", "AichiParser", "KanagawaParser", "HyogoParser",
-    "SaitamaParser", "ChibaParser", "HokkaidoParser", "PARSERS",
+    "SaitamaParser", "ChibaParser", "HokkaidoParser", "GifuParser", "PARSERS",
 ]

--- a/batch/parsers/gifu.py
+++ b/batch/parsers/gifu.py
@@ -1,0 +1,165 @@
+"""岐阜銭湯組合 (gifu1010.com) パーサー。"""
+import logging
+import re
+from typing import Optional
+from urllib.parse import parse_qs, unquote, urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+from parsers.base import BaseParser
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://gifu1010.com"
+LIST_URL = f"{BASE_URL}/"
+
+_DETAIL_URL_PATTERN = re.compile(r"/sento/[^/?#]+/?$")
+_COORD_PAIR_PATTERN = re.compile(r"\s*([\-\d.]+)\s*,\s*([\-\d.]+)\s*")
+_AT_COORD_PATTERN = re.compile(r"/@([\-\d.]+),([\-\d.]+)(?:,|$)")
+
+
+class GifuParser(BaseParser):
+    prefecture = "岐阜県"
+    region = "中部"
+
+    def get_list_urls(self) -> list[str]:
+        return [LIST_URL]
+
+    def get_item_urls(self, html: str, page_url: str) -> list[str]:
+        soup = BeautifulSoup(html, "lxml")
+        urls: list[str] = []
+        seen: set[str] = set()
+
+        for a in soup.find_all("a", href=True):
+            href: str = a["href"]
+            if not _DETAIL_URL_PATTERN.search(href):
+                continue
+            if not href.startswith("http"):
+                href = urljoin(BASE_URL, href)
+            if href not in seen:
+                seen.add(href)
+                urls.append(href)
+
+        return urls
+
+    def parse_sento(self, html: str, page_url: str) -> Optional[dict]:
+        soup = BeautifulSoup(html, "lxml")
+
+        name = self._extract_name(soup)
+        if not name:
+            logger.warning("name が取得できません: %s", page_url)
+            return None
+
+        address = (
+            self.extract_label_value(soup, "住所")
+            or self.extract_table_value(soup, "住所")
+            or self._extract_text_by_selector(soup, [".address", ".shopAddress", "address"])
+            or ""
+        )
+        if not address:
+            logger.warning("address が取得できません: %s", page_url)
+            return None
+
+        phone = (
+            self.extract_label_value(soup, "TEL")
+            or self.extract_label_value(soup, "電話")
+            or self.extract_table_value(soup, "TEL")
+            or self.extract_table_value(soup, "電話")
+        )
+        if not phone:
+            tel_tag = soup.find("a", href=re.compile(r"^tel:"))
+            if tel_tag:
+                phone = tel_tag["href"].replace("tel:", "").strip()
+
+        open_hours = (
+            self.extract_label_value(soup, "営業時間")
+            or self.extract_table_value(soup, "営業時間")
+            or self.extract_table_value(soup, "営業")
+        )
+        holiday = (
+            self.extract_label_value(soup, "定休日")
+            or self.extract_label_value(soup, "休日")
+            or self.extract_table_value(soup, "定休日")
+            or self.extract_table_value(soup, "休日")
+        )
+
+        lat: Optional[float] = None
+        lng: Optional[float] = None
+        for a in soup.find_all("a", href=True):
+            coords = self._extract_coords_from_maps_url(a["href"])
+            if coords is None:
+                continue
+            lat, lng = coords
+            break
+
+        return {
+            **self.make_sento_dict(
+                name=name,
+                address=address,
+                lat=lat,
+                lng=lng,
+                phone=phone,
+                open_hours=open_hours,
+                holiday=holiday,
+                source_url=page_url,
+            ),
+            "facility_type": "sento",
+        }
+
+    @staticmethod
+    def _extract_name(soup: BeautifulSoup) -> Optional[str]:
+        for selector in ("h1", "h2", ".sentoName", ".shopName", ".entry-title"):
+            tag = soup.select_one(selector)
+            if not tag:
+                continue
+            raw = tag.get_text(strip=True)
+            if raw and len(raw) < 80:
+                return raw
+
+        title = soup.title.get_text(strip=True) if soup.title else ""
+        if title:
+            head = re.split(r"[|｜：:]", title)[0].strip()
+            if head and len(head) < 80:
+                return head
+
+        return None
+
+    @staticmethod
+    def _extract_text_by_selector(soup: BeautifulSoup, selectors: list[str]) -> Optional[str]:
+        for selector in selectors:
+            tag = soup.select_one(selector)
+            if tag:
+                value = tag.get_text(" ", strip=True)
+                if value:
+                    return value
+        return None
+
+    @staticmethod
+    def _extract_coords_from_maps_url(url: str) -> Optional[tuple[float, float]]:
+        parsed = urlparse(url)
+
+        # 短縮URLや非地図URLは対象外
+        if "google" not in parsed.netloc and "google" not in parsed.path:
+            return None
+        if "maps" not in parsed.path and "maps" not in parsed.netloc:
+            return None
+
+        query = parse_qs(parsed.query)
+        for key in ("q", "ll", "destination"):
+            raw = query.get(key, [""])[0]
+            m = _COORD_PAIR_PATTERN.fullmatch(unquote(raw))
+            if not m:
+                continue
+            try:
+                return float(m.group(1)), float(m.group(2))
+            except ValueError:
+                continue
+
+        m = _AT_COORD_PATTERN.search(unquote(url))
+        if m:
+            try:
+                return float(m.group(1)), float(m.group(2))
+            except ValueError:
+                return None
+
+        return None

--- a/batch/tests/test_gifu_parser.py
+++ b/batch/tests/test_gifu_parser.py
@@ -1,0 +1,140 @@
+"""GifuParser のユニットテスト。"""
+import pytest
+
+from parsers import PARSERS
+from parsers.gifu import GifuParser
+
+
+@pytest.fixture
+def parser() -> GifuParser:
+    return GifuParser()
+
+
+def test_parser_registered() -> None:
+    assert "岐阜県" in PARSERS
+    assert PARSERS["岐阜県"] is GifuParser
+
+
+def test_get_list_urls(parser: GifuParser) -> None:
+    assert parser.get_list_urls() == ["https://gifu1010.com/"]
+
+
+GIFU_LIST_HTML = """
+<html>
+<body>
+  <a href="/sento/いずみ湯">いずみ湯</a>
+  <a href="/sento/かぎや温泉">かぎや温泉</a>
+  <a href="/sento/いずみ湯">重複</a>
+  <a href="/info/">お知らせ</a>
+</body>
+</html>
+"""
+
+
+def test_get_item_urls_extracts_and_deduplicates(parser: GifuParser) -> None:
+    urls = parser.get_item_urls(GIFU_LIST_HTML, "https://gifu1010.com/")
+    assert urls == [
+        "https://gifu1010.com/sento/いずみ湯",
+        "https://gifu1010.com/sento/かぎや温泉",
+    ]
+
+
+GIFU_DETAIL_HTML_HAPPY = """
+<html>
+<body>
+  <h1>いずみ湯</h1>
+  <table>
+    <tr><th>住所</th><td>岐阜県岐阜市泉町1-2-3</td></tr>
+    <tr><th>TEL</th><td>058-111-2222</td></tr>
+    <tr><th>営業時間</th><td>15:00〜23:30</td></tr>
+    <tr><th>定休日</th><td>火曜日</td></tr>
+  </table>
+  <a href="https://www.google.com/maps?q=35.4233,136.7606">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_happy_path(parser: GifuParser) -> None:
+    url = "https://gifu1010.com/sento/いずみ湯"
+    result = parser.parse_sento(GIFU_DETAIL_HTML_HAPPY, url)
+
+    assert result is not None
+    assert result["name"] == "いずみ湯"
+    assert result["address"] == "岐阜県岐阜市泉町1-2-3"
+    assert result["phone"] == "058-111-2222"
+    assert result["open_hours"] == "15:00〜23:30"
+    assert result["holiday"] == "火曜日"
+    assert result["lat"] == pytest.approx(35.4233)
+    assert result["lng"] == pytest.approx(136.7606)
+    assert result["prefecture"] == "岐阜県"
+    assert result["region"] == "中部"
+    assert result["facility_type"] == "sento"
+    assert result["source_url"] == url
+
+
+GIFU_DETAIL_HTML_MAPS_DEST = """
+<html>
+<body>
+  <h1>かぎや温泉</h1>
+  <dl>
+    <dt>住所</dt><dd>岐阜県岐阜市鍵屋町9-9</dd>
+    <dt>営業時間</dt><dd>14:00〜22:00</dd>
+  </dl>
+  <a href="https://www.google.com/maps?destination=35.4001,136.7620">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_coords_from_destination(parser: GifuParser) -> None:
+    result = parser.parse_sento(GIFU_DETAIL_HTML_MAPS_DEST, "https://gifu1010.com/sento/かぎや温泉")
+    assert result is not None
+    assert result["lat"] == pytest.approx(35.4001)
+    assert result["lng"] == pytest.approx(136.7620)
+
+
+GIFU_DETAIL_HTML_TEL_ONLY = """
+<html>
+<body>
+  <h1>音羽湯</h1>
+  <dl>
+    <dt>住所</dt><dd>岐阜県大垣市音羽町3-4</dd>
+    <dt>営業時間</dt><dd>16:00〜23:00</dd>
+  </dl>
+  <a href="tel:0584-11-1111">電話</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_phone_from_tel_link(parser: GifuParser) -> None:
+    result = parser.parse_sento(GIFU_DETAIL_HTML_TEL_ONLY, "https://gifu1010.com/sento/音羽湯")
+    assert result is not None
+    assert result["phone"] == "0584-11-1111"
+
+
+def test_parse_sento_lat_lng_none_when_no_maps_link(parser: GifuParser) -> None:
+    result = parser.parse_sento(GIFU_DETAIL_HTML_TEL_ONLY, "https://gifu1010.com/sento/音羽湯")
+    assert result is not None
+    assert result["lat"] is None
+    assert result["lng"] is None
+
+
+def test_parse_sento_returns_none_when_name_missing(parser: GifuParser) -> None:
+    html = """
+    <html><body>
+      <dl><dt>住所</dt><dd>岐阜県岐阜市1-2-3</dd></dl>
+    </body></html>
+    """
+    assert parser.parse_sento(html, "https://gifu1010.com/sento/unknown") is None
+
+
+def test_parse_sento_returns_none_when_address_missing(parser: GifuParser) -> None:
+    html = """
+    <html><body>
+      <h1>平和湯</h1>
+      <p>住所情報なし</p>
+    </body></html>
+    """
+    assert parser.parse_sento(html, "https://gifu1010.com/sento/heiwa") is None


### PR DESCRIPTION
## Summary
- `batch/parsers/gifu.py` 新規作成（gifu1010.com 静的HTML）

## Test plan
- [x] `PARSERS["岐阜県"]` が登録されていること（9テスト全パス）

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)