### PR TITLE
feat(EXPAND-shizuoka): 静岡県銭湯パーサー実装

### DIFF
--- a/batch/parsers/__init__.py
+++ b/batch/parsers/__init__.py
@@ -10,6 +10,7 @@ from parsers.hyogo import HyogoParser
 from parsers.saitama import SaitamaParser
 from parsers.chiba import ChibaParser
 from parsers.hokkaido import HokkaidoParser
+from parsers.shizuoka import ShizuokaParser
 
 PARSERS: dict[str, type[BaseParser]] = {
     "東京都": TokyoParser,
@@ -22,10 +23,11 @@ PARSERS: dict[str, type[BaseParser]] = {
     "埼玉県": SaitamaParser,
     "千葉県": ChibaParser,
     "北海道": HokkaidoParser,
+    "静岡県": ShizuokaParser,
 }
 
 __all__ = [
     "BaseParser", "TokyoParser", "KyotoParser", "FukuokaParser",
     "OsakaParser", "AichiParser", "KanagawaParser", "HyogoParser",
-    "SaitamaParser", "ChibaParser", "HokkaidoParser", "PARSERS",
+    "SaitamaParser", "ChibaParser", "HokkaidoParser", "ShizuokaParser", "PARSERS",
 ]

--- a/batch/parsers/shizuoka.py
+++ b/batch/parsers/shizuoka.py
@@ -1,0 +1,216 @@
+"""静岡県銭湯組合 (shizuoka1010.com) パーサー。"""
+import logging
+import re
+from typing import Optional
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+from parsers.base import BaseParser
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://shizuoka1010.com"
+LIST_URL = f"{BASE_URL}/"
+
+_GOOGLE_MAP_HOST_PATTERN = re.compile(r"(?:^|\.)google\.[^/]+$")
+_MAPS_COORD_PATTERNS = (
+    re.compile(r"[?&]q=([-\d.]+),([-\d.]+)"),
+    re.compile(r"[?&]ll=([-\d.]+),([-\d.]+)"),
+    re.compile(r"[?&]destination=([-\d.]+),([-\d.]+)"),
+    re.compile(r"[?&]daddr=([-\d.]+),([-\d.]+)"),
+    re.compile(r"@([-\d.]+),([-\d.]+),"),
+    re.compile(r"!3d([-\d.]+)!.*!4d([-\d.]+)"),
+)
+_TEL_INLINE_PATTERN = re.compile(r"(?:TEL|電話)\s*[:：]?\s*(\d{2,4}-\d{2,4}-\d{3,4})")
+_STATIC_FILE_PATTERN = re.compile(r"\.(?:jpg|jpeg|png|gif|svg|pdf|zip)$", re.IGNORECASE)
+_EXCLUDED_PATH_PARTS = (
+    "/news",
+    "/topics",
+    "/blog",
+    "/about",
+    "/contact",
+    "/privacy",
+    "/policy",
+    "/association",
+    "/kumiai",
+)
+_DETAIL_HINT_PARTS = ("/shop/", "/sento/", "/bath/", "/store/")
+
+
+class ShizuokaParser(BaseParser):
+    prefecture = "静岡県"
+    region = "中部"
+
+    def get_list_urls(self) -> list[str]:
+        return [LIST_URL]
+
+    def get_item_urls(self, html: str, page_url: str) -> list[str]:
+        soup = BeautifulSoup(html, "lxml")
+        urls: list[str] = []
+        seen: set[str] = set()
+        normalized_page_url = self._normalize_url(page_url)
+
+        for a in soup.find_all("a", href=True):
+            href = str(a["href"]).strip()
+            if not href:
+                continue
+            abs_url = self._normalize_url(urljoin(BASE_URL, href))
+            if not abs_url:
+                continue
+            if abs_url == normalized_page_url:
+                continue
+            if not self._is_candidate_detail_url(abs_url):
+                continue
+            if abs_url in seen:
+                continue
+            seen.add(abs_url)
+            urls.append(abs_url)
+
+        return urls
+
+    def parse_sento(self, html: str, page_url: str) -> Optional[dict]:
+        soup = BeautifulSoup(html, "lxml")
+
+        name = self._extract_name(soup)
+        if not name:
+            logger.warning("name が取得できません: %s", page_url)
+            return None
+
+        address = self._extract_address(soup)
+        if not address:
+            logger.warning("address が取得できません: %s", page_url)
+            return None
+
+        phone = self._extract_phone(soup)
+        open_hours = (
+            self.extract_label_value(soup, "営業時間")
+            or self.extract_table_value(soup, "営業時間")
+            or self.extract_table_value(soup, "営業")
+        )
+        holiday = (
+            self.extract_label_value(soup, "定休日")
+            or self.extract_label_value(soup, "休日")
+            or self.extract_table_value(soup, "定休日")
+            or self.extract_table_value(soup, "休業日")
+            or self.extract_table_value(soup, "休日")
+        )
+
+        lat, lng = self._extract_coords(soup)
+
+        return {
+            **self.make_sento_dict(
+                name=name,
+                address=address,
+                lat=lat,
+                lng=lng,
+                phone=phone,
+                open_hours=open_hours,
+                holiday=holiday,
+                source_url=page_url,
+            ),
+            "facility_type": "sento",
+        }
+
+    def _extract_name(self, soup: BeautifulSoup) -> Optional[str]:
+        for selector in ("h1", "h2", ".entry-title", ".post-title", ".shop-title"):
+            tag = soup.select_one(selector)
+            if not tag:
+                continue
+            raw = tag.get_text(strip=True)
+            if raw and len(raw) < 80:
+                return raw
+        title_tag = soup.find("title")
+        if title_tag:
+            raw_title = title_tag.get_text(strip=True)
+            if raw_title:
+                return raw_title.split("|")[0].split("｜")[0].strip()
+        return None
+
+    def _extract_address(self, soup: BeautifulSoup) -> Optional[str]:
+        address = (
+            self.extract_label_value(soup, "住所")
+            or self.extract_table_value(soup, "住所")
+        )
+        if address:
+            return address
+
+        text = soup.get_text(" ", strip=True)
+        m = re.search(r"(静岡県[^ ]{3,100})", text)
+        return m.group(1) if m else None
+
+    def _extract_phone(self, soup: BeautifulSoup) -> Optional[str]:
+        tel_link = soup.find("a", href=re.compile(r"^tel:"))
+        if tel_link:
+            return str(tel_link["href"]).replace("tel:", "").strip()
+
+        phone = (
+            self.extract_label_value(soup, "TEL")
+            or self.extract_label_value(soup, "電話")
+            or self.extract_table_value(soup, "TEL")
+            or self.extract_table_value(soup, "電話")
+        )
+        if phone:
+            return phone
+
+        m = _TEL_INLINE_PATTERN.search(soup.get_text(" ", strip=True))
+        return m.group(1) if m else None
+
+    def _extract_coords(self, soup: BeautifulSoup) -> tuple[Optional[float], Optional[float]]:
+        for tag in soup.find_all(["a", "iframe"], href=True):
+            lat, lng = self._extract_coords_from_url(str(tag["href"]))
+            if lat is not None:
+                return lat, lng
+
+        for iframe in soup.find_all("iframe", src=True):
+            lat, lng = self._extract_coords_from_url(str(iframe["src"]))
+            if lat is not None:
+                return lat, lng
+
+        return None, None
+
+    def _extract_coords_from_url(self, url: str) -> tuple[Optional[float], Optional[float]]:
+        try:
+            parsed = urlparse(url)
+        except ValueError:
+            return None, None
+
+        host = parsed.netloc.lower()
+        if "maps.app.goo.gl" not in host and not _GOOGLE_MAP_HOST_PATTERN.search(host):
+            return None, None
+        if "maps" not in parsed.path and "maps" not in url and "goo.gl" not in host:
+            return None, None
+
+        for pattern in _MAPS_COORD_PATTERNS:
+            m = pattern.search(url)
+            if not m:
+                continue
+            try:
+                return float(m.group(1)), float(m.group(2))
+            except ValueError:
+                continue
+        return None, None
+
+    def _is_candidate_detail_url(self, url: str) -> bool:
+        parsed = urlparse(url)
+        if "shizuoka1010.com" not in parsed.netloc.lower():
+            return False
+        if parsed.scheme not in ("http", "https"):
+            return False
+        if _STATIC_FILE_PATTERN.search(parsed.path):
+            return False
+        lowered = parsed.path.lower()
+        if any(part in lowered for part in _EXCLUDED_PATH_PARTS):
+            return False
+        if any(part in lowered for part in _DETAIL_HINT_PARTS):
+            return True
+        depth = len([seg for seg in lowered.split("/") if seg])
+        return depth >= 1
+
+    @staticmethod
+    def _normalize_url(url: str) -> str:
+        parsed = urlparse(url)
+        if not parsed.scheme or not parsed.netloc:
+            return ""
+        clean = parsed._replace(fragment="").geturl()
+        return clean.rstrip("/")

--- a/batch/tests/test_shizuoka_parser.py
+++ b/batch/tests/test_shizuoka_parser.py
@@ -1,0 +1,143 @@
+"""ShizuokaParser のユニットテスト。"""
+import pytest
+
+from parsers import PARSERS
+from parsers.shizuoka import ShizuokaParser
+
+
+@pytest.fixture
+def parser() -> ShizuokaParser:
+    return ShizuokaParser()
+
+
+def test_parser_registered_in_parsers_dict() -> None:
+    assert "静岡県" in PARSERS
+    assert PARSERS["静岡県"] is ShizuokaParser
+
+
+def test_get_list_urls(parser: ShizuokaParser) -> None:
+    assert parser.get_list_urls() == ["https://shizuoka1010.com/"]
+
+
+SHIZUOKA_LIST_HTML = """
+<html>
+<body>
+  <a href="/shop/atami-yu/">熱海湯</a>
+  <a href="https://shizuoka1010.com/sento/shimizu-yu/">清水湯</a>
+  <a href="/shop/atami-yu/">熱海湯（重複）</a>
+  <a href="/news/2026/notice">お知らせ</a>
+  <a href="/contact/">お問い合わせ</a>
+  <a href="https://example.com/shop/outside/">外部</a>
+  <a href="/assets/map.pdf">PDF</a>
+</body>
+</html>
+"""
+
+
+def test_get_item_urls_extracts_internal_detail_links(parser: ShizuokaParser) -> None:
+    urls = parser.get_item_urls(SHIZUOKA_LIST_HTML, "https://shizuoka1010.com/")
+    assert "https://shizuoka1010.com/shop/atami-yu" in urls
+    assert "https://shizuoka1010.com/sento/shimizu-yu" in urls
+    assert "https://example.com/shop/outside" not in urls
+    assert all("/news/" not in u for u in urls)
+    assert all("/contact/" not in u for u in urls)
+    assert all(not u.endswith(".pdf") for u in urls)
+
+
+def test_get_item_urls_deduplicates(parser: ShizuokaParser) -> None:
+    html = """
+    <html><body>
+      <a href="/shop/kakegawa-yu/">掛川湯</a>
+      <a href="https://shizuoka1010.com/shop/kakegawa-yu/">掛川湯（重複）</a>
+    </body></html>
+    """
+    urls = parser.get_item_urls(html, "https://shizuoka1010.com/")
+    assert urls == ["https://shizuoka1010.com/shop/kakegawa-yu"]
+
+
+SHIZUOKA_DETAIL_HTML_HAPPY = """
+<html>
+<body>
+  <h1>熱海湯</h1>
+  <dl>
+    <dt>住所</dt><dd>静岡県熱海市銀座町1-2-3</dd>
+    <dt>TEL</dt><dd>0557-11-2233</dd>
+    <dt>営業時間</dt><dd>14:00〜23:00</dd>
+    <dt>定休日</dt><dd>火曜日</dd>
+  </dl>
+  <a href="https://www.google.com/maps?q=35.0952,139.0710">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_happy_path(parser: ShizuokaParser) -> None:
+    url = "https://shizuoka1010.com/shop/atami-yu/"
+    result = parser.parse_sento(SHIZUOKA_DETAIL_HTML_HAPPY, url)
+    assert result is not None
+    assert result["name"] == "熱海湯"
+    assert result["address"] == "静岡県熱海市銀座町1-2-3"
+    assert result["phone"] == "0557-11-2233"
+    assert result["open_hours"] == "14:00〜23:00"
+    assert result["holiday"] == "火曜日"
+    assert result["lat"] == pytest.approx(35.0952)
+    assert result["lng"] == pytest.approx(139.0710)
+    assert result["prefecture"] == "静岡県"
+    assert result["region"] == "中部"
+    assert result["facility_type"] == "sento"
+    assert result["source_url"] == url
+
+
+SHIZUOKA_DETAIL_HTML_IFRAME = """
+<html>
+<body>
+  <h1>清水湯</h1>
+  <table>
+    <tr><th>住所</th><td>静岡県静岡市清水区4-5-6</td></tr>
+  </table>
+  <iframe src="https://www.google.com/maps/embed?pb=!1m18!...!3d34.9850!...!4d138.4890!..."></iframe>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_coords_from_iframe(parser: ShizuokaParser) -> None:
+    result = parser.parse_sento(SHIZUOKA_DETAIL_HTML_IFRAME, "https://shizuoka1010.com/shop/shimizu-yu/")
+    assert result is not None
+    assert result["lat"] == pytest.approx(34.9850)
+    assert result["lng"] == pytest.approx(138.4890)
+
+
+SHIZUOKA_DETAIL_HTML_NO_COORDS = """
+<html>
+<body>
+  <h1>富士見湯</h1>
+  <dl>
+    <dt>住所</dt><dd>静岡県富士市7-8-9</dd>
+    <dt>電話</dt><dd>0545-12-3456</dd>
+  </dl>
+  <a href="https://maps.app.goo.gl/abcdef123456">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_returns_none_coords_when_not_in_map_url(parser: ShizuokaParser) -> None:
+    result = parser.parse_sento(SHIZUOKA_DETAIL_HTML_NO_COORDS, "https://shizuoka1010.com/shop/fujimi-yu/")
+    assert result is not None
+    assert result["lat"] is None
+    assert result["lng"] is None
+
+
+def test_parse_sento_returns_none_when_name_missing(parser: ShizuokaParser) -> None:
+    html = """
+    <html><body><dl><dt>住所</dt><dd>静岡県浜松市1-1-1</dd></dl></body></html>
+    """
+    assert parser.parse_sento(html, "https://shizuoka1010.com/shop/unknown/") is None
+
+
+def test_parse_sento_returns_none_when_address_missing(parser: ShizuokaParser) -> None:
+    html = """
+    <html><body><h1>名無し湯</h1><p>住所情報なし</p></body></html>
+    """
+    assert parser.parse_sento(html, "https://shizuoka1010.com/shop/no-address/") is None


### PR DESCRIPTION
## Summary
- `batch/parsers/shizuoka.py` 新規作成（shizuoka1010.com 店舗一覧）

## Test plan
- [x] `PARSERS["静岡県"]` が登録されていること（9テスト全パス）

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)