### PR TITLE
feat(EXPAND-shiga): 滋賀県銭湯パーサー実装

### DIFF
--- a/batch/parsers/__init__.py
+++ b/batch/parsers/__init__.py
@@ -10,6 +10,7 @@ from parsers.hyogo import HyogoParser
 from parsers.saitama import SaitamaParser
 from parsers.chiba import ChibaParser
 from parsers.hokkaido import HokkaidoParser
+from parsers.shiga import ShigaParser
 
 PARSERS: dict[str, type[BaseParser]] = {
     "東京都": TokyoParser,
@@ -22,10 +23,11 @@ PARSERS: dict[str, type[BaseParser]] = {
     "埼玉県": SaitamaParser,
     "千葉県": ChibaParser,
     "北海道": HokkaidoParser,
+    "滋賀県": ShigaParser,
 }
 
 __all__ = [
     "BaseParser", "TokyoParser", "KyotoParser", "FukuokaParser",
     "OsakaParser", "AichiParser", "KanagawaParser", "HyogoParser",
-    "SaitamaParser", "ChibaParser", "HokkaidoParser", "PARSERS",
+    "SaitamaParser", "ChibaParser", "HokkaidoParser", "ShigaParser", "PARSERS",
 ]

--- a/batch/parsers/shiga.py
+++ b/batch/parsers/shiga.py
@@ -1,0 +1,219 @@
+"""滋賀県銭湯組合 (shiga1010.com) パーサー。"""
+import logging
+import re
+from typing import Optional
+from urllib.parse import parse_qs, unquote, urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+from parsers.base import BaseParser
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://shiga1010.com"
+LIST_URL = f"{BASE_URL}/"
+
+_DETAIL_HINTS = (
+    "/sento/",
+    "/bath/",
+    "/bathhouse/",
+    "/shop/",
+    "/introduce/",
+)
+_EXCLUDE_PATH_KEYWORDS = (
+    "/contact",
+    "/privacy",
+    "/policy",
+    "/about",
+    "/news",
+    "/category/",
+    "/tag/",
+    "/feed",
+    "/wp-admin",
+    "/wp-json",
+)
+_SKIP_EXT_PATTERN = re.compile(r"\.(?:pdf|jpg|jpeg|png|gif|webp|svg|zip)$", re.IGNORECASE)
+_PHONE_PATTERN = re.compile(r"\d{2,4}-\d{2,4}-\d{3,4}")
+
+_GMAPS_Q_PATTERN = re.compile(r"[?&]q=([-\d.]+),([-\d.]+)")
+_GMAPS_LL_PATTERN = re.compile(r"[?&]ll=([-\d.]+),([-\d.]+)")
+_DESTINATION_PATTERN = re.compile(r"[?&]destination=([-\d.]+),([-\d.]+)")
+_CENTER_PATTERN = re.compile(r"[?&]center=([-\d.]+)(?:%2C|,)([-\d.]+)")
+_AT_PATTERN = re.compile(r"/@([-\d.]+),([-\d.]+)")
+_EMBED_PATTERN = re.compile(r"!3d([-\d.]+)!4d([-\d.]+)")
+
+
+class ShigaParser(BaseParser):
+    prefecture = "滋賀県"
+    region = "近畿"
+
+    def get_list_urls(self) -> list[str]:
+        return [LIST_URL]
+
+    def get_item_urls(self, html: str, page_url: str) -> list[str]:
+        soup = BeautifulSoup(html, "lxml")
+        urls: list[str] = []
+        seen: set[str] = set()
+
+        for a in soup.find_all("a", href=True):
+            href = str(a["href"]).strip()
+            if not href or href.startswith(("#", "javascript:", "mailto:", "tel:")):
+                continue
+
+            url = href if href.startswith("http") else urljoin(BASE_URL, href)
+            parsed = urlparse(url)
+            if "shiga1010.com" not in parsed.netloc:
+                continue
+            if _SKIP_EXT_PATTERN.search(parsed.path):
+                continue
+            if url == page_url or parsed.path in ("", "/"):
+                continue
+            if any(k in parsed.path for k in _EXCLUDE_PATH_KEYWORDS):
+                continue
+
+            anchor_text = a.get_text(" ", strip=True)
+            if self._is_detail_candidate(parsed.path, anchor_text) and url not in seen:
+                seen.add(url)
+                urls.append(url)
+
+        return urls
+
+    def parse_sento(self, html: str, page_url: str) -> Optional[dict]:
+        soup = BeautifulSoup(html, "lxml")
+
+        name: Optional[str] = None
+        for selector in ("h1.entry-title", "h1", "h2.entry-title", "h2"):
+            tag = soup.select_one(selector)
+            if not tag:
+                continue
+            raw = tag.get_text(strip=True)
+            if raw and len(raw) < 80:
+                name = raw
+                break
+
+        if not name:
+            title = soup.title.get_text(strip=True) if soup.title else ""
+            title = re.sub(r"\s*[\-|｜|].*$", "", title).strip()
+            if title:
+                name = title
+
+        if not name:
+            logger.warning("name が取得できません: %s", page_url)
+            return None
+
+        address = (
+            self.extract_label_value(soup, "住所")
+            or self.extract_table_value(soup, "住所")
+            or self._extract_by_text_pattern(soup.get_text("\n", strip=True), "住所")
+            or ""
+        )
+
+        phone = (
+            self.extract_label_value(soup, "電話")
+            or self.extract_label_value(soup, "TEL")
+            or self.extract_table_value(soup, "電話")
+            or self.extract_table_value(soup, "TEL")
+        )
+        if not phone:
+            tel_tag = soup.find("a", href=re.compile(r"^tel:"))
+            if tel_tag:
+                phone = str(tel_tag["href"]).replace("tel:", "").strip()
+            else:
+                text_match = _PHONE_PATTERN.search(soup.get_text(" ", strip=True))
+                if text_match:
+                    phone = text_match.group(0)
+
+        open_hours = (
+            self.extract_label_value(soup, "営業時間")
+            or self.extract_table_value(soup, "営業時間")
+            or self._extract_by_text_pattern(soup.get_text("\n", strip=True), "営業時間")
+        )
+        holiday = (
+            self.extract_label_value(soup, "定休日")
+            or self.extract_label_value(soup, "休日")
+            or self.extract_table_value(soup, "定休日")
+            or self.extract_table_value(soup, "休日")
+            or self._extract_by_text_pattern(soup.get_text("\n", strip=True), "定休日")
+        )
+
+        lat: Optional[float] = None
+        lng: Optional[float] = None
+
+        for tag in soup.find_all(["a", "iframe"], href=True):
+            href = str(tag["href"])
+            if "google." not in href or "maps" not in href:
+                continue
+            lat, lng = self._extract_coords_from_gmaps_url(href)
+            if lat is not None:
+                break
+
+        if lat is None:
+            for iframe in soup.find_all("iframe", src=True):
+                src = str(iframe["src"])
+                if "google." not in src or "maps" not in src:
+                    continue
+                lat, lng = self._extract_coords_from_gmaps_url(src)
+                if lat is not None:
+                    break
+
+        return {
+            **self.make_sento_dict(
+                name=name,
+                address=address,
+                lat=lat,
+                lng=lng,
+                phone=phone,
+                open_hours=open_hours,
+                holiday=holiday,
+                source_url=page_url,
+            ),
+            "facility_type": "sento",
+        }
+
+    @staticmethod
+    def _is_detail_candidate(path: str, anchor_text: str) -> bool:
+        if any(hint in path for hint in _DETAIL_HINTS):
+            return True
+        if "銭湯" in anchor_text or "湯" in anchor_text:
+            # 一覧/地図リンクは除外する。
+            return not any(x in path for x in ("/list", "/map"))
+        return False
+
+    @staticmethod
+    def _extract_by_text_pattern(text: str, label: str) -> Optional[str]:
+        m = re.search(rf"{re.escape(label)}\s*[:：]\s*([^\n]+)", text)
+        if m:
+            return m.group(1).strip()
+        return None
+
+    @staticmethod
+    def _extract_coords_from_gmaps_url(url: str) -> tuple[Optional[float], Optional[float]]:
+        decoded = unquote(url)
+
+        for pattern in (_GMAPS_Q_PATTERN, _DESTINATION_PATTERN, _GMAPS_LL_PATTERN, _CENTER_PATTERN, _AT_PATTERN):
+            m = pattern.search(decoded)
+            if m:
+                try:
+                    return float(m.group(1)), float(m.group(2))
+                except ValueError:
+                    pass
+
+        m_embed = _EMBED_PATTERN.search(decoded)
+        if m_embed:
+            try:
+                return float(m_embed.group(1)), float(m_embed.group(2))
+            except ValueError:
+                pass
+
+        parsed = urlparse(decoded)
+        qs = parse_qs(parsed.query)
+        if "query" in qs:
+            q = qs["query"][0]
+            m = re.search(r"([-\d.]+),([-\d.]+)", q)
+            if m:
+                try:
+                    return float(m.group(1)), float(m.group(2))
+                except ValueError:
+                    pass
+
+        return None, None

--- a/batch/tests/test_shiga_parser.py
+++ b/batch/tests/test_shiga_parser.py
@@ -1,0 +1,138 @@
+"""ShigaParser のユニットテスト。"""
+import pytest
+
+from parsers.shiga import ShigaParser
+
+
+@pytest.fixture
+def parser() -> ShigaParser:
+    return ShigaParser()
+
+
+def test_get_list_urls(parser: ShigaParser) -> None:
+    assert parser.get_list_urls() == ["https://shiga1010.com/"]
+
+
+SHIGA_LIST_HTML = """
+<html>
+<body>
+  <a href="/sento/otsu-yu/">大津湯</a>
+  <a href="https://shiga1010.com/bath/kusatsu-no-yu/">草津の湯</a>
+  <a href="/shop/ritto-yu/">栗東湯</a>
+  <a href="/list/">一覧ページ（除外）</a>
+  <a href="/contact/">お問い合わせ（除外）</a>
+  <a href="https://example.com/sento/ext/">外部（除外）</a>
+  <a href="/sento/otsu-yu/">大津湯（重複）</a>
+</body>
+</html>
+"""
+
+
+def test_get_item_urls_collects_detail_urls_only(parser: ShigaParser) -> None:
+    urls = parser.get_item_urls(SHIGA_LIST_HTML, "https://shiga1010.com/")
+    assert urls == [
+        "https://shiga1010.com/sento/otsu-yu/",
+        "https://shiga1010.com/bath/kusatsu-no-yu/",
+        "https://shiga1010.com/shop/ritto-yu/",
+    ]
+
+
+SHIGA_DETAIL_HTML_HAPPY = """
+<html>
+<body>
+  <h1>大津湯</h1>
+  <dl>
+    <dt>住所</dt><dd>滋賀県大津市中央1-2-3</dd>
+    <dt>TEL</dt><dd>077-123-4567</dd>
+    <dt>営業時間</dt><dd>15:00〜23:00</dd>
+    <dt>定休日</dt><dd>木曜日</dd>
+  </dl>
+  <a href="https://www.google.com/maps?q=35.0045,135.8686">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_happy_path(parser: ShigaParser) -> None:
+    result = parser.parse_sento(SHIGA_DETAIL_HTML_HAPPY, "https://shiga1010.com/sento/otsu-yu/")
+
+    assert result is not None
+    assert result["name"] == "大津湯"
+    assert result["address"] == "滋賀県大津市中央1-2-3"
+    assert result["phone"] == "077-123-4567"
+    assert result["open_hours"] == "15:00〜23:00"
+    assert result["holiday"] == "木曜日"
+    assert result["lat"] == pytest.approx(35.0045)
+    assert result["lng"] == pytest.approx(135.8686)
+    assert result["prefecture"] == "滋賀県"
+    assert result["region"] == "近畿"
+    assert result["facility_type"] == "sento"
+
+
+SHIGA_DETAIL_HTML_IFRAME = """
+<html>
+<body>
+  <h1>草津の湯</h1>
+  <table>
+    <tr><th>住所</th><td>滋賀県草津市1-1-1</td></tr>
+    <tr><th>電話</th><td>077-987-6543</td></tr>
+  </table>
+  <iframe src="https://www.google.com/maps/embed?pb=!1m18!2m3!1d0!2d0!3d35.0211!4d135.9599"></iframe>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_coords_from_iframe_embed(parser: ShigaParser) -> None:
+    result = parser.parse_sento(SHIGA_DETAIL_HTML_IFRAME, "https://shiga1010.com/bath/kusatsu-no-yu/")
+    assert result is not None
+    assert result["lat"] == pytest.approx(35.0211)
+    assert result["lng"] == pytest.approx(135.9599)
+
+
+SHIGA_DETAIL_HTML_NO_COORDS = """
+<html>
+<body>
+  <h1>守山湯</h1>
+  <p>住所：滋賀県守山市2-3-4</p>
+  <a href="https://www.google.com/maps/place/%E5%AE%88%E5%B1%B1%E6%B9%AF/">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_returns_none_coords_when_not_available(parser: ShigaParser) -> None:
+    result = parser.parse_sento(SHIGA_DETAIL_HTML_NO_COORDS, "https://shiga1010.com/sento/moriyama-yu/")
+    assert result is not None
+    assert result["lat"] is None
+    assert result["lng"] is None
+
+
+SHIGA_DETAIL_HTML_TITLE_FALLBACK = """
+<html>
+<head><title>石山湯 | 滋賀県浴場組合</title></head>
+<body>
+  <p>住所：滋賀県大津市石山寺1-2-3</p>
+  <a href="tel:077-111-2222">電話</a>
+  <a href="https://www.google.com/maps?destination=34.9800,135.9000">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_uses_title_fallback_for_name(parser: ShigaParser) -> None:
+    result = parser.parse_sento(
+        SHIGA_DETAIL_HTML_TITLE_FALLBACK,
+        "https://shiga1010.com/sento/ishiyama-yu/",
+    )
+    assert result is not None
+    assert result["name"] == "石山湯"
+    assert result["phone"] == "077-111-2222"
+    assert result["lat"] == pytest.approx(34.9800)
+    assert result["lng"] == pytest.approx(135.9000)
+
+
+def test_parse_sento_returns_none_when_name_missing(parser: ShigaParser) -> None:
+    html = "<html><body><p>住所: 滋賀県甲賀市1-2-3</p></body></html>"
+    result = parser.parse_sento(html, "https://shiga1010.com/sento/unknown/")
+    assert result is None


### PR DESCRIPTION
## Summary
- `batch/parsers/shiga.py` 新規作成（shiga1010.com 静的HTML）

## Test plan
- [x] `PARSERS["滋賀県"]` が登録されていること（7テスト全パス）

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)