### PR TITLE
feat(EXPAND-nara): 奈良県銭湯パーサー実装

### DIFF
--- a/batch/parsers/__init__.py
+++ b/batch/parsers/__init__.py
@@ -10,6 +10,7 @@ from parsers.hyogo import HyogoParser
 from parsers.saitama import SaitamaParser
 from parsers.chiba import ChibaParser
 from parsers.hokkaido import HokkaidoParser
+from parsers.nara import NaraParser
 
 PARSERS: dict[str, type[BaseParser]] = {
     "東京都": TokyoParser,
@@ -22,10 +23,11 @@ PARSERS: dict[str, type[BaseParser]] = {
     "埼玉県": SaitamaParser,
     "千葉県": ChibaParser,
     "北海道": HokkaidoParser,
+    "奈良県": NaraParser,
 }
 
 __all__ = [
     "BaseParser", "TokyoParser", "KyotoParser", "FukuokaParser",
     "OsakaParser", "AichiParser", "KanagawaParser", "HyogoParser",
-    "SaitamaParser", "ChibaParser", "HokkaidoParser", "PARSERS",
+    "SaitamaParser", "ChibaParser", "HokkaidoParser", "NaraParser", "PARSERS",
 ]

--- a/batch/parsers/nara.py
+++ b/batch/parsers/nara.py
@@ -1,0 +1,227 @@
+"""奈良県銭湯組合 (nara1010.com) パーサー。"""
+import logging
+import re
+from typing import Optional
+from urllib.parse import urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+from parsers.base import BaseParser
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://nara1010.com"
+LIST_URL = f"{BASE_URL}/"
+
+# Google Maps リンクから緯度経度を抽出
+_GMAPS_Q_PATTERN = re.compile(r"[?&]q=([-\d.]+),([-\d.]+)")
+_DESTINATION_PATTERN = re.compile(r"destination=([-\d.]+),([-\d.]+)")
+_GMAPS_LL_PATTERN = re.compile(r"[?&]ll=([-\d.]+),([-\d.]+)")
+_DADDR_PATTERN = re.compile(r"[?&]daddr=([-\d.]+),([-\d.]+)")
+_QUERY_PATTERN = re.compile(r"[?&]query=([-\d.]+),([-\d.]+)")
+_AT_PATTERN = re.compile(r"@([-\d.]+),([-\d.]+)")
+
+# 一覧・共通ページとみなすパス断片（個別ページ URL 抽出から除外）
+_EXCLUDE_PATH_KEYWORDS = (
+    "/wp-admin",
+    "/wp-login",
+    "/privacy",
+    "/contact",
+    "/news",
+    "/category/",
+    "/tag/",
+    "/author/",
+    "/feed",
+)
+
+# 個別ページ URL とみなすパス断片
+_DETAIL_HINTS = (
+    "/sento",
+    "/bath",
+    "/koten",
+    "/shop",
+    "/store",
+)
+
+
+class NaraParser(BaseParser):
+    prefecture = "奈良県"
+    region = "近畿"
+
+    def get_list_urls(self) -> list[str]:
+        return [LIST_URL]
+
+    def get_item_urls(self, html: str, page_url: str) -> list[str]:
+        soup = BeautifulSoup(html, "lxml")
+        urls: list[str] = []
+        seen: set[str] = set()
+
+        for a in soup.find_all("a", href=True):
+            raw_href = str(a["href"]).strip()
+            if not raw_href:
+                continue
+
+            url = urljoin(BASE_URL, raw_href)
+            parsed = urlparse(url)
+
+            if parsed.scheme not in ("http", "https"):
+                continue
+            if parsed.netloc not in ("nara1010.com", "www.nara1010.com"):
+                continue
+
+            normalized = f"{parsed.scheme}://{parsed.netloc}{parsed.path}".rstrip("/") + "/"
+            if normalized == LIST_URL and not parsed.query:
+                continue
+            if any(k in parsed.path for k in _EXCLUDE_PATH_KEYWORDS):
+                continue
+
+            label = a.get_text(" ", strip=True)
+            is_detail = self._looks_like_detail_url(parsed.path, parsed.query, label)
+            if not is_detail:
+                continue
+
+            final_url = normalized
+            if parsed.query:
+                final_url = f"{final_url}?{parsed.query}"
+
+            if final_url not in seen:
+                seen.add(final_url)
+                urls.append(final_url)
+
+        return urls
+
+    @staticmethod
+    def _looks_like_detail_url(path: str, query: str, label: str) -> bool:
+        lower_path = path.lower()
+        lower_query = query.lower()
+        lower_label = label.lower()
+
+        if any(hint in lower_path for hint in _DETAIL_HINTS):
+            return True
+
+        if re.search(r"(?:^|&)p=\d+(?:&|$)", lower_query):
+            return True
+
+        # WordPress の投稿 URL（/2026/03/...）と固定ページ（?p=123）以外の単独スラッグを許可
+        if re.search(r"/\d{4}/\d{2}/\d{2}/", lower_path):
+            return True
+        if re.search(r"/[^/]+/$", lower_path) and "/" != lower_path:
+            if lower_path.count("/") <= 2:
+                return True
+
+        if any(token in lower_label for token in ("詳細", "店舗", "銭湯", "浴場")):
+            return True
+
+        return False
+
+    def parse_sento(self, html: str, page_url: str) -> Optional[dict]:
+        soup = BeautifulSoup(html, "lxml")
+
+        name: Optional[str] = None
+        for selector in ("h1", "h2.entry-title", "h2", "h3"):
+            tag = soup.select_one(selector)
+            if not tag:
+                continue
+            raw = tag.get_text(" ", strip=True)
+            if raw and len(raw) <= 80:
+                name = raw
+                break
+
+        if not name:
+            title_tag = soup.find("title")
+            if title_tag:
+                title = title_tag.get_text(" ", strip=True)
+                title = title.split("|")[0].split("｜")[0].strip()
+                if title:
+                    name = title
+
+        if not name:
+            logger.warning("name が取得できません: %s", page_url)
+            return None
+
+        address = (
+            self.extract_label_value(soup, "住所")
+            or self.extract_table_value(soup, "住所")
+            or self._extract_address_from_text(soup)
+            or ""
+        )
+
+        if not address:
+            logger.warning("address が取得できません: %s", page_url)
+            return None
+
+        phone = (
+            self.extract_label_value(soup, "TEL")
+            or self.extract_label_value(soup, "電話")
+            or self.extract_table_value(soup, "TEL")
+            or self.extract_table_value(soup, "電話")
+        )
+        if not phone:
+            tel_tag = soup.find("a", href=re.compile(r"^tel:"))
+            if tel_tag:
+                phone = str(tel_tag["href"]).replace("tel:", "").strip()
+
+        open_hours = (
+            self.extract_label_value(soup, "営業時間")
+            or self.extract_table_value(soup, "営業時間")
+            or self.extract_label_value(soup, "営業")
+            or self.extract_table_value(soup, "営業")
+        )
+        holiday = (
+            self.extract_label_value(soup, "定休日")
+            or self.extract_table_value(soup, "定休日")
+            or self.extract_label_value(soup, "休日")
+            or self.extract_table_value(soup, "休日")
+        )
+
+        lat, lng = self._extract_coords_from_google_maps(soup)
+
+        return {
+            **self.make_sento_dict(
+                name=name,
+                address=address,
+                lat=lat,
+                lng=lng,
+                phone=phone,
+                open_hours=open_hours,
+                holiday=holiday,
+                source_url=page_url,
+            ),
+            "facility_type": "sento",
+        }
+
+    @staticmethod
+    def _extract_address_from_text(soup: BeautifulSoup) -> Optional[str]:
+        text = soup.get_text("\n", strip=True)
+        # 例: 住所: 奈良県奈良市...
+        m = re.search(r"住所[:：]\s*(.+)", text)
+        if m:
+            value = m.group(1).strip()
+            if value:
+                return value
+        return None
+
+    @staticmethod
+    def _extract_coords_from_google_maps(soup: BeautifulSoup) -> tuple[Optional[float], Optional[float]]:
+        for a in soup.find_all("a", href=True):
+            href = str(a["href"])
+            if "google." not in href or "/maps" not in href:
+                continue
+
+            for pattern in (
+                _GMAPS_Q_PATTERN,
+                _DESTINATION_PATTERN,
+                _GMAPS_LL_PATTERN,
+                _DADDR_PATTERN,
+                _QUERY_PATTERN,
+                _AT_PATTERN,
+            ):
+                m = pattern.search(href)
+                if not m:
+                    continue
+                try:
+                    return float(m.group(1)), float(m.group(2))
+                except ValueError:
+                    continue
+
+        return None, None

--- a/batch/tests/test_nara_parser.py
+++ b/batch/tests/test_nara_parser.py
@@ -1,0 +1,151 @@
+"""NaraParser のユニットテスト。"""
+import pytest
+
+from parsers import PARSERS
+from parsers.nara import NaraParser
+
+
+@pytest.fixture
+def parser() -> NaraParser:
+    return NaraParser()
+
+
+def test_registered_in_parsers() -> None:
+    assert PARSERS["奈良県"] is NaraParser
+
+
+def test_get_list_urls(parser: NaraParser) -> None:
+    assert parser.get_list_urls() == ["https://nara1010.com/"]
+
+
+NARA_LIST_HTML = """
+<html>
+<body>
+  <a href="/sento/matsu-yu/">松の湯</a>
+  <a href="https://nara1010.com/shop/ume-yu/">梅の湯</a>
+  <a href="/?p=123">竹の湯</a>
+  <a href="https://example.com/sento/outside/">外部</a>
+  <a href="/privacy/">プライバシー</a>
+  <a href="/">トップ</a>
+  <a href="/sento/matsu-yu/">重複</a>
+</body>
+</html>
+"""
+
+
+def test_get_item_urls_extracts_internal_detail_urls(parser: NaraParser) -> None:
+    urls = parser.get_item_urls(NARA_LIST_HTML, "https://nara1010.com/")
+
+    assert "https://nara1010.com/sento/matsu-yu/" in urls
+    assert "https://nara1010.com/shop/ume-yu/" in urls
+    assert "https://nara1010.com/?p=123" in urls
+    assert all("example.com" not in u for u in urls)
+    assert all("privacy" not in u for u in urls)
+
+
+def test_get_item_urls_deduplicates(parser: NaraParser) -> None:
+    urls = parser.get_item_urls(NARA_LIST_HTML, "https://nara1010.com/")
+    assert urls.count("https://nara1010.com/sento/matsu-yu/") == 1
+
+
+NARA_DETAIL_HTML_HAPPY = """
+<html>
+<head><title>松の湯 | 奈良県浴場組合</title></head>
+<body>
+  <h1>松の湯</h1>
+  <dl>
+    <dt>住所</dt><dd>奈良県奈良市三条町1-2-3</dd>
+    <dt>TEL</dt><dd>0742-11-2233</dd>
+    <dt>営業時間</dt><dd>14:00-24:00</dd>
+    <dt>定休日</dt><dd>月曜日</dd>
+  </dl>
+  <a href="https://www.google.com/maps?q=34.6851,135.8048">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_happy_path(parser: NaraParser) -> None:
+    result = parser.parse_sento(NARA_DETAIL_HTML_HAPPY, "https://nara1010.com/sento/matsu-yu/")
+
+    assert result is not None
+    assert result["name"] == "松の湯"
+    assert result["address"] == "奈良県奈良市三条町1-2-3"
+    assert result["phone"] == "0742-11-2233"
+    assert result["open_hours"] == "14:00-24:00"
+    assert result["holiday"] == "月曜日"
+    assert result["lat"] == pytest.approx(34.6851)
+    assert result["lng"] == pytest.approx(135.8048)
+    assert result["prefecture"] == "奈良県"
+    assert result["region"] == "近畿"
+    assert result["facility_type"] == "sento"
+
+
+NARA_DETAIL_HTML_TABLE_TEL = """
+<html>
+<body>
+  <h1>梅の湯</h1>
+  <table>
+    <tr><th>住所</th><td>奈良県大和郡山市2-3-4</td></tr>
+    <tr><th>営業時間</th><td>15:00-22:30</td></tr>
+    <tr><th>定休日</th><td>木曜日</td></tr>
+  </table>
+  <a href="tel:0743-55-6677">電話</a>
+  <a href="https://www.google.com/maps/dir/?api=1&destination=34.6490,135.7820">地図</a>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_extracts_tel_and_destination_coords(parser: NaraParser) -> None:
+    result = parser.parse_sento(NARA_DETAIL_HTML_TABLE_TEL, "https://nara1010.com/shop/ume-yu/")
+
+    assert result is not None
+    assert result["phone"] == "0743-55-6677"
+    assert result["lat"] == pytest.approx(34.6490)
+    assert result["lng"] == pytest.approx(135.7820)
+
+
+NARA_DETAIL_HTML_NO_COORDS = """
+<html>
+<body>
+  <h1>竹の湯</h1>
+  <p>住所: 奈良県橿原市5-6-7</p>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_sets_coords_none_when_no_maps_link(parser: NaraParser) -> None:
+    result = parser.parse_sento(NARA_DETAIL_HTML_NO_COORDS, "https://nara1010.com/sento/take-yu/")
+    assert result is not None
+    assert result["lat"] is None
+    assert result["lng"] is None
+
+
+NARA_DETAIL_HTML_NO_NAME = """
+<html>
+<body>
+  <p>住所: 奈良県奈良市1-1-1</p>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_returns_none_when_name_missing(parser: NaraParser) -> None:
+    result = parser.parse_sento(NARA_DETAIL_HTML_NO_NAME, "https://nara1010.com/sento/unknown/")
+    assert result is None
+
+
+NARA_DETAIL_HTML_NO_ADDRESS = """
+<html>
+<body>
+  <h1>名無し湯</h1>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_returns_none_when_address_missing(parser: NaraParser) -> None:
+    result = parser.parse_sento(NARA_DETAIL_HTML_NO_ADDRESS, "https://nara1010.com/sento/no-address/")
+    assert result is None


### PR DESCRIPTION
## Summary
- `batch/parsers/nara.py` 新規作成（nara1010.com 静的HTML）

## Test plan
- [x] `PARSERS["奈良県"]` が登録されていること（9テスト全パス）

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)