### PR TITLE
feat(EXPAND-okayama): 岡山県OSMインポート対応

### DIFF
--- a/batch/tests/test_osm_geocoder.py
+++ b/batch/tests/test_osm_geocoder.py
@@ -1,10 +1,16 @@
 """osm_geocoder モジュールのユニットテスト。"""
+from unittest.mock import Mock
+
 import pytest
 
 from osm_geocoder import (
+    PARSER_IMPLEMENTED_PREFECTURES,
+    PREFECTURE_NAMES,
+    PREFECTURE_TO_REGION,
     _build_address,
     extract_coords,
     find_best_match,
+    import_new_prefecture,
     resolve_facility_type,
 )
 
@@ -151,3 +157,45 @@ def test_build_address_addr_full_takes_precedence_in_caller() -> None:
     tags = {"addr:province": "愛知県", "addr:city": "名古屋市"}
     result = _build_address(tags, "愛知県")
     assert result == "愛知県名古屋市"
+
+
+# ---------------------------------------------------------------------------
+# OSM import target prefectures
+# ---------------------------------------------------------------------------
+
+def test_okayama_in_prefecture_names() -> None:
+    assert "岡山県" in PREFECTURE_NAMES
+
+
+def test_okayama_region_is_chugoku() -> None:
+    assert PREFECTURE_TO_REGION["岡山県"] == "中国"
+
+
+def test_okayama_not_in_parser_implemented_prefectures() -> None:
+    assert "岡山県" not in PARSER_IMPLEMENTED_PREFECTURES
+
+
+def test_import_new_okayama_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    elements = [
+        {
+            "type": "node",
+            "id": 3101,
+            "lat": 34.6618,
+            "lon": 133.9350,
+            "tags": {"name": "岡山湯", "amenity": "public_bath"},
+        }
+    ]
+    monkeypatch.setattr("osm_geocoder.fetch_osm_bath_facilities", lambda _: elements)
+
+    fetchone_result = Mock()
+    fetchone_result.fetchone.return_value = None
+    session = Mock()
+    session.execute.return_value = fetchone_result
+
+    inserted, skipped, total = import_new_prefecture(session, "岡山県", dry_run=True)
+
+    assert inserted == 1
+    assert skipped == 0
+    assert total == 1
+    assert session.execute.call_count == 1
+    session.commit.assert_not_called()


### PR DESCRIPTION
## 概要
issue #31 の対応として、岡山県を OSM-only で扱うことをテストで担保しました。

## 変更内容
- `batch/tests/test_osm_geocoder.py` に岡山県向けテストを追加
  - `PREFECTURE_NAMES` に岡山県が含まれる
  - `PREFECTURE_TO_REGION["岡山県"] == "中国"`
  - `PARSER_IMPLEMENTED_PREFECTURES` に岡山県が含まれない
  - `import_new_prefecture(..., dry_run=True)` で INSERT件数が正しくカウントされ、`commit` が呼ばれない

## テスト
- `UV_CACHE_DIR=/tmp/.uv-cache uv run pytest`（`batch/`）
- 86 passed

Closes #31
