### PR TITLE
feat(EXPAND-oita): 大分県OSMインポート対応

### DIFF
--- a/batch/tests/test_osm_geocoder.py
+++ b/batch/tests/test_osm_geocoder.py
@@ -1,10 +1,16 @@
 """osm_geocoder モジュールのユニットテスト。"""
+from unittest.mock import Mock
+
 import pytest
 
 from osm_geocoder import (
+    PARSER_IMPLEMENTED_PREFECTURES,
+    PREFECTURE_NAMES,
+    PREFECTURE_TO_REGION,
     _build_address,
     extract_coords,
     find_best_match,
+    import_new_prefecture,
     resolve_facility_type,
 )
 
@@ -151,3 +157,49 @@ def test_build_address_addr_full_takes_precedence_in_caller() -> None:
     tags = {"addr:province": "愛知県", "addr:city": "名古屋市"}
     result = _build_address(tags, "愛知県")
     assert result == "愛知県名古屋市"
+
+
+# ---------------------------------------------------------------------------
+# OSM import target prefectures
+# ---------------------------------------------------------------------------
+
+def test_oita_in_prefecture_names() -> None:
+    assert "大分県" in PREFECTURE_NAMES
+
+
+def test_oita_region_is_kyushu() -> None:
+    assert PREFECTURE_TO_REGION["大分県"] == "九州"
+
+
+def test_oita_not_in_parser_implemented_prefectures() -> None:
+    assert "大分県" not in PARSER_IMPLEMENTED_PREFECTURES
+
+
+def test_import_new_oita_dry_run_with_onsen_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    elements = [
+        {
+            "type": "node",
+            "id": 4401,
+            "lat": 33.2396,
+            "lon": 131.6093,
+            "tags": {
+                "name": "別府温泉浴場",
+                "amenity": "public_bath",
+                "bath:type": "onsen",
+            },
+        }
+    ]
+    monkeypatch.setattr("osm_geocoder.fetch_osm_bath_facilities", lambda _: elements)
+
+    fetchone_result = Mock()
+    fetchone_result.fetchone.return_value = None
+    session = Mock()
+    session.execute.return_value = fetchone_result
+
+    inserted, skipped, total = import_new_prefecture(session, "大分県", dry_run=True)
+
+    assert inserted == 1
+    assert skipped == 0
+    assert total == 1
+    assert resolve_facility_type(elements[0]["tags"]) == "onsen"
+    session.commit.assert_not_called()


### PR DESCRIPTION
## 概要
issue #44 の対応として、大分県を OSM-only で扱うためのテストを追加しました。

## 変更内容
- `batch/tests/test_osm_geocoder.py`
  - `PREFECTURE_NAMES` に大分県が含まれること
  - `PREFECTURE_TO_REGION["大分県"] == "九州"`
  - `PARSER_IMPLEMENTED_PREFECTURES` に大分県が含まれないこと
  - `import_new_prefecture(..., "大分県", dry_run=True)` の動作検証
  - `bath:type=onsen` の場合に `facility_type="onsen"` になることを検証

## テスト
- `UV_CACHE_DIR=/tmp/.uv-cache uv run pytest`（`batch/`）
- 86 passed

Closes #44
