### PR TITLE
feat(EXPAND-okinawa): 沖縄県パーサー実装

### DIFF
--- a/batch/parsers/__init__.py
+++ b/batch/parsers/__init__.py
@@ -10,6 +10,7 @@ from parsers.hyogo import HyogoParser
 from parsers.saitama import SaitamaParser
 from parsers.chiba import ChibaParser
 from parsers.hokkaido import HokkaidoParser
+from parsers.okinawa import OkinawaParser
 
 PARSERS: dict[str, type[BaseParser]] = {
     "東京都": TokyoParser,
@@ -22,10 +23,11 @@ PARSERS: dict[str, type[BaseParser]] = {
     "埼玉県": SaitamaParser,
     "千葉県": ChibaParser,
     "北海道": HokkaidoParser,
+    "沖縄県": OkinawaParser,
 }
 
 __all__ = [
     "BaseParser", "TokyoParser", "KyotoParser", "FukuokaParser",
     "OsakaParser", "AichiParser", "KanagawaParser", "HyogoParser",
-    "SaitamaParser", "ChibaParser", "HokkaidoParser", "PARSERS",
+    "SaitamaParser", "ChibaParser", "HokkaidoParser", "OkinawaParser", "PARSERS",
 ]

--- a/batch/parsers/okinawa.py
+++ b/batch/parsers/okinawa.py
@@ -1,0 +1,264 @@
+"""沖縄県銭湯サイト (okinawa-sento.jp) パーサー。
+
+実運用前に robots.txt と利用規約を確認すること。
+"""
+import logging
+import re
+from typing import Optional
+from urllib.parse import parse_qs, urljoin, urlparse
+
+from bs4 import BeautifulSoup
+
+from parsers.base import BaseParser
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://okinawa-sento.jp"
+TOP_URL = f"{BASE_URL}/"
+
+_POST_URL_PATTERN = re.compile(r"/\d{4}/\d{2}/\d{2}/")
+_DETAIL_HINT_PATTERN = re.compile(r"/(?:sento|bath|shop|facility|store)/")
+
+_GMAPS_Q_PATTERN = re.compile(r"[?&]q=([-\d.]+),([-\d.]+)")
+_GMAPS_LL_PATTERN = re.compile(r"[?&]ll=([-\d.]+),([-\d.]+)")
+_GMAPS_DEST_PATTERN = re.compile(r"[?&]destination=([-\d.]+),([-\d.]+)")
+_GMAPS_QUERY_PATTERN = re.compile(r"[?&]query=([-\d.]+),([-\d.]+)")
+_GMAPS_AT_PATTERN = re.compile(r"/@([-\d.]+),([-\d.]+)")
+_GMAPS_EMBED_PATTERN = re.compile(r"!3d([-\d.]+)!.*!4d([-\d.]+)")
+_GMAPS_EMBED_2D3D_PATTERN = re.compile(r"!2d([-\d.]+)!3d([-\d.]+)")
+
+_LIST_PATH_KEYWORDS = (
+    "/category/",
+    "/tag/",
+    "/author/",
+    "/page/",
+    "/news/",
+    "/blog/",
+    "/archives/",
+    "/list",
+)
+_SENTO_PAGE_HINTS = ("住所", "営業時間", "定休日", "電話", "TEL", "入浴")
+_EXCLUDED_DETAIL_PATHS = {
+    "/about",
+    "/contact",
+    "/privacy-policy",
+    "/terms",
+    "/sitemap",
+}
+
+
+class OkinawaParser(BaseParser):
+    prefecture = "沖縄県"
+    region = "九州"
+
+    def get_list_urls(self) -> list[str]:
+        return [TOP_URL]
+
+    def get_all_list_urls(self, page1_html: str) -> list[str]:
+        soup = BeautifulSoup(page1_html, "lxml")
+        urls: list[str] = [TOP_URL]
+        seen: set[str] = {TOP_URL}
+
+        for a in soup.find_all("a", href=True):
+            href = self._normalize_href(a["href"])
+            if not href or not self._is_internal_url(href):
+                continue
+
+            text = a.get_text(" ", strip=True)
+            if not self._is_list_like_url(href, text):
+                continue
+
+            if href not in seen:
+                seen.add(href)
+                urls.append(href)
+
+        return urls
+
+    def get_item_urls(self, html: str, page_url: str) -> list[str]:
+        soup = BeautifulSoup(html, "lxml")
+        urls: list[str] = []
+        seen: set[str] = set()
+
+        for a in soup.select("article a[href], .post a[href], .entry a[href], h2 a[href], h3 a[href]"):
+            href = self._normalize_href(a.get("href", ""))
+            if href and self._is_sento_detail_url(href) and href not in seen:
+                seen.add(href)
+                urls.append(href)
+
+        if urls:
+            return urls
+
+        for a in soup.find_all("a", href=True):
+            href = self._normalize_href(a["href"])
+            if href and self._is_sento_detail_url(href) and href not in seen:
+                seen.add(href)
+                urls.append(href)
+
+        return urls
+
+    def parse_sento(self, html: str, page_url: str) -> Optional[dict]:
+        soup = BeautifulSoup(html, "lxml")
+
+        if self._is_list_like_url(page_url, "") and not self._looks_like_sento_page(soup):
+            return None
+
+        name: Optional[str] = None
+        for selector in ("h1.entry-title", "h1.post-title", ".entry-title", "h1", "h2"):
+            tag = soup.select_one(selector)
+            if not tag:
+                continue
+            raw = tag.get_text(strip=True)
+            if raw and len(raw) < 80:
+                name = raw
+                break
+
+        if not name:
+            logger.warning("name が取得できません: %s", page_url)
+            return None
+
+        address = (
+            self.extract_label_value(soup, "住所")
+            or self.extract_table_value(soup, "住所")
+            or (soup.find("address").get_text(" ", strip=True) if soup.find("address") else None)
+        )
+        if not address:
+            logger.warning("address が取得できません: %s", page_url)
+            return None
+
+        phone = (
+            self.extract_label_value(soup, "TEL")
+            or self.extract_label_value(soup, "電話")
+            or self.extract_table_value(soup, "TEL")
+            or self.extract_table_value(soup, "電話")
+        )
+        if not phone:
+            tel_tag = soup.find("a", href=re.compile(r"^tel:"))
+            if tel_tag:
+                phone = str(tel_tag["href"]).replace("tel:", "").strip()
+
+        open_hours = self.extract_label_value(soup, "営業時間") or self.extract_table_value(soup, "営業時間")
+        holiday = (
+            self.extract_label_value(soup, "定休日")
+            or self.extract_label_value(soup, "休日")
+            or self.extract_table_value(soup, "定休日")
+            or self.extract_table_value(soup, "休業日")
+            or self.extract_table_value(soup, "休日")
+        )
+
+        lat, lng = self._extract_coordinates(soup)
+
+        return self.make_sento_dict(
+            name=name,
+            address=address,
+            lat=lat,
+            lng=lng,
+            phone=phone,
+            open_hours=open_hours,
+            holiday=holiday,
+            source_url=page_url,
+            facility_type="sento",
+        )
+
+    def _extract_coordinates(self, soup: BeautifulSoup) -> tuple[Optional[float], Optional[float]]:
+        for a in soup.find_all("a", href=True):
+            href = a["href"]
+            if "google.com/maps" not in href and "maps.app.goo.gl" not in href:
+                continue
+            coords = self._extract_coordinates_from_url(href)
+            if coords is not None:
+                return coords
+
+        for iframe in soup.find_all("iframe", src=True):
+            src = iframe["src"]
+            if "google.com/maps" not in src and "maps.google.com" not in src:
+                continue
+            coords = self._extract_coordinates_from_url(src)
+            if coords is not None:
+                return coords
+
+        return None, None
+
+    def _extract_coordinates_from_url(self, url: str) -> Optional[tuple[float, float]]:
+        for pattern in (
+            _GMAPS_Q_PATTERN,
+            _GMAPS_LL_PATTERN,
+            _GMAPS_DEST_PATTERN,
+            _GMAPS_QUERY_PATTERN,
+            _GMAPS_AT_PATTERN,
+            _GMAPS_EMBED_PATTERN,
+            _GMAPS_EMBED_2D3D_PATTERN,
+        ):
+            matched = pattern.search(url)
+            if matched:
+                try:
+                    first = float(matched.group(1))
+                    second = float(matched.group(2))
+                    if pattern is _GMAPS_EMBED_2D3D_PATTERN:
+                        return second, first
+                    return first, second
+                except ValueError:
+                    continue
+
+        parsed = urlparse(url)
+        query = parse_qs(parsed.query)
+        for key in ("q", "ll", "query", "destination"):
+            value = query.get(key, [])
+            if not value:
+                continue
+            parts = value[0].split(",")
+            if len(parts) != 2:
+                continue
+            try:
+                return float(parts[0]), float(parts[1])
+            except ValueError:
+                continue
+
+        return None
+
+    def _normalize_href(self, href: str) -> Optional[str]:
+        if not href or href.startswith("#"):
+            return None
+        normalized = href.strip()
+        if not normalized.startswith("http"):
+            normalized = urljoin(BASE_URL, normalized)
+        return normalized.rstrip("/")
+
+    def _is_internal_url(self, url: str) -> bool:
+        netloc = urlparse(url).netloc.lower()
+        return netloc in {"okinawa-sento.jp", "www.okinawa-sento.jp"}
+
+    def _is_list_like_url(self, href: str, text: str) -> bool:
+        parsed = urlparse(href)
+        lowered_text = text.lower()
+
+        if any(keyword in parsed.path for keyword in _LIST_PATH_KEYWORDS):
+            return True
+        if any(token in lowered_text for token in ("一覧", "エリア", "search", "カテゴリ", "銭湯")):
+            return True
+        if "cat" in parse_qs(parsed.query):
+            return True
+        return False
+
+    def _is_sento_detail_url(self, url: str) -> bool:
+        if not self._is_internal_url(url):
+            return False
+
+        parsed = urlparse(url)
+        path = parsed.path.lower()
+        if any(token in path for token in ("/wp-admin", "/wp-login", "/wp-json", "/feed")):
+            return False
+        if any(keyword in path for keyword in _LIST_PATH_KEYWORDS):
+            return False
+        if _POST_URL_PATTERN.search(path):
+            return True
+        if _DETAIL_HINT_PATTERN.search(path):
+            return True
+        if path in ("", "/"):
+            return False
+        if path in _EXCLUDED_DETAIL_PATHS:
+            return False
+        return False
+
+    def _looks_like_sento_page(self, soup: BeautifulSoup) -> bool:
+        text = soup.get_text(separator="\n")
+        return sum(1 for hint in _SENTO_PAGE_HINTS if hint in text) >= 2

--- a/batch/tests/test_okinawa_parser.py
+++ b/batch/tests/test_okinawa_parser.py
@@ -1,0 +1,132 @@
+"""OkinawaParser のユニットテスト。"""
+import pytest
+
+from parsers import PARSERS
+from parsers.okinawa import OkinawaParser
+
+
+@pytest.fixture
+def parser() -> OkinawaParser:
+    return OkinawaParser()
+
+
+OKINAWA_TOP_HTML = """
+<html>
+<body>
+  <a href="https://okinawa-sento.jp/category/sento/">銭湯一覧</a>
+  <a href="/category/news/">お知らせ</a>
+  <a href="https://example.com/category/sento/">外部</a>
+</body>
+</html>
+"""
+
+
+OKINAWA_LIST_HTML = """
+<html>
+<body>
+  <article><h2><a href="https://okinawa-sento.jp/2025/01/10/naha-yu/">那覇湯</a></h2></article>
+  <article><h2><a href="/2025/02/01/uruma-yu/">うるま湯</a></h2></article>
+  <a href="https://okinawa-sento.jp/category/sento/">一覧（除外）</a>
+  <a href="https://okinawa-sento.jp/wp-admin/">管理（除外）</a>
+</body>
+</html>
+"""
+
+
+OKINAWA_DETAIL_HTML_HAPPY = """
+<html>
+<body>
+  <h1 class="entry-title">那覇湯</h1>
+  <dl>
+    <dt>住所</dt><dd>沖縄県那覇市1-2-3</dd>
+    <dt>TEL</dt><dd>098-123-4567</dd>
+    <dt>営業時間</dt><dd>15:00〜23:00</dd>
+    <dt>定休日</dt><dd>火曜日</dd>
+  </dl>
+  <a href="https://www.google.com/maps?q=26.2124,127.6809">地図</a>
+</body>
+</html>
+"""
+
+
+OKINAWA_DETAIL_HTML_IFRAME = """
+<html>
+<body>
+  <h1>うるま湯</h1>
+  <dl><dt>住所</dt><dd>沖縄県うるま市2-3-4</dd></dl>
+  <iframe src="https://www.google.com/maps/embed?pb=!1m18!2d127.8575!3d26.3344"></iframe>
+</body>
+</html>
+"""
+
+
+OKINAWA_DETAIL_HTML_NO_ADDRESS = """
+<html>
+<body>
+  <h1>住所なし湯</h1>
+</body>
+</html>
+"""
+
+
+OKINAWA_DETAIL_HTML_NO_NAME = """
+<html>
+<body>
+  <dl><dt>住所</dt><dd>沖縄県沖縄市3-4-5</dd></dl>
+</body>
+</html>
+"""
+
+
+def test_parse_sento_happy_path(parser: OkinawaParser) -> None:
+    result = parser.parse_sento(OKINAWA_DETAIL_HTML_HAPPY, "https://okinawa-sento.jp/2025/01/10/naha-yu/")
+
+    assert result is not None
+    assert result["name"] == "那覇湯"
+    assert result["address"] == "沖縄県那覇市1-2-3"
+    assert result["phone"] == "098-123-4567"
+    assert result["open_hours"] == "15:00〜23:00"
+    assert result["holiday"] == "火曜日"
+    assert result["lat"] == pytest.approx(26.2124)
+    assert result["lng"] == pytest.approx(127.6809)
+    assert result["prefecture"] == "沖縄県"
+    assert result["region"] == "九州"
+    assert result["facility_type"] == "sento"
+
+
+def test_parse_sento_extracts_coordinates_from_iframe(parser: OkinawaParser) -> None:
+    result = parser.parse_sento(OKINAWA_DETAIL_HTML_IFRAME, "https://okinawa-sento.jp/2025/02/01/uruma-yu/")
+    assert result is not None
+    assert result["lat"] == pytest.approx(26.3344)
+    assert result["lng"] == pytest.approx(127.8575)
+
+
+def test_parse_sento_returns_none_when_address_missing(parser: OkinawaParser) -> None:
+    result = parser.parse_sento(OKINAWA_DETAIL_HTML_NO_ADDRESS, "https://okinawa-sento.jp/2025/03/01/no-address/")
+    assert result is None
+
+
+def test_parse_sento_returns_none_when_name_missing(parser: OkinawaParser) -> None:
+    result = parser.parse_sento(OKINAWA_DETAIL_HTML_NO_NAME, "https://okinawa-sento.jp/2025/03/01/no-name/")
+    assert result is None
+
+
+def test_get_all_list_urls_collects_list_pages(parser: OkinawaParser) -> None:
+    urls = parser.get_all_list_urls(OKINAWA_TOP_HTML)
+    assert "https://okinawa-sento.jp/" in urls
+    assert "https://okinawa-sento.jp/category/sento" in urls
+    assert "https://okinawa-sento.jp/category/news" in urls
+    assert all("example.com" not in url for url in urls)
+
+
+def test_get_item_urls_extracts_detail_urls(parser: OkinawaParser) -> None:
+    urls = parser.get_item_urls(OKINAWA_LIST_HTML, "https://okinawa-sento.jp/category/sento/")
+    assert "https://okinawa-sento.jp/2025/01/10/naha-yu" in urls
+    assert "https://okinawa-sento.jp/2025/02/01/uruma-yu" in urls
+    assert all("/category/" not in url for url in urls)
+    assert all("/wp-admin" not in url for url in urls)
+
+
+def test_parsers_contains_okinawa() -> None:
+    assert "沖縄県" in PARSERS
+    assert PARSERS["沖縄県"] is OkinawaParser


### PR DESCRIPTION
## 概要
issue #47 の対応として、`okinawa-sento.jp` 向けの沖縄県パーサーを追加しました。

## 変更内容
- `batch/parsers/okinawa.py` を追加
- `batch/parsers/__init__.py` に `OkinawaParser` 登録
- `batch/tests/test_okinawa_parser.py` を追加

## テスト
- `UV_CACHE_DIR=/tmp/.uv-cache uv run pytest`（`batch/`）
- 89 passed

Closes #47
